### PR TITLE
Fix reactions and comments to use Turbo Stream in-place DOM updates

### DIFF
--- a/.claude/skills/ux-review/SKILL.md
+++ b/.claude/skills/ux-review/SKILL.md
@@ -69,6 +69,13 @@ Also test at a narrow viewport (375px) to catch mobile/responsive issues.
 - [ ] Is text contrast sufficient in both light and dark mode?
 - [ ] Are images or icons meaningful to screen readers (alt text or aria-label)?
 
+### In-Place Updates (PWA)
+- [ ] Do interactive actions (reactions, comments, toggles, form submissions) update the DOM in place without a full page reload?
+- [ ] Are Turbo Stream responses used for create/update/destroy actions instead of `redirect_to`?
+- [ ] Does the page maintain scroll position after user interactions?
+- [ ] Do forms reset after successful submission (textarea cleared, not stale)?
+- [ ] Is there no visible page flash or full-page re-render on user actions?
+
 ### Responsive
 - [ ] Does the layout hold at 375px width without horizontal scrolling?
 - [ ] Are touch targets large enough on mobile (44x44px minimum)?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This document provides instructions and protocols for AI Agents interacting with
 
 - **Live Testing:** Use the `agent-browser` tool to verify changes visually or functionally.
 
+- **GitHub CLI:** Always `unset GITHUB_TOKEN` before running `gh` commands. The environment may have a stale token that causes `HTTP 401: Bad credentials` errors. The `gh` CLI falls back to its own auth store when the env var is unset.
+
     - **Local URL:** `https://catalyst.workeverywhere.docker`
 
 ---

--- a/app/components/comment_form.rb
+++ b/app/components/comment_form.rb
@@ -11,21 +11,23 @@ module Components
     end
 
     def view_template
-      form_with(
-        model: [@trip, @entry, @comment],
-        class: "flex gap-3"
-      ) do |form|
-        div(class: "flex-1") do
-          form.text_area(
-            :body,
-            placeholder: "Add a comment...",
-            rows: 2,
-            class: "ha-input w-full text-sm"
-          )
-        end
-        div(class: "flex items-end") do
-          form.submit "Post",
-                      class: "ha-button ha-button-primary text-sm"
+      div(id: "comment_form_#{@entry.id}") do
+        form_with(
+          model: [@trip, @entry, @comment],
+          class: "flex gap-3"
+        ) do |form|
+          div(class: "flex-1") do
+            form.text_area(
+              :body,
+              placeholder: "Add a comment...",
+              rows: 2,
+              class: "ha-input w-full text-sm"
+            )
+          end
+          div(class: "flex items-end") do
+            form.submit "Post",
+                        class: "ha-button ha-button-primary text-sm"
+          end
         end
       end
     end

--- a/app/components/reaction_summary.rb
+++ b/app/components/reaction_summary.rb
@@ -21,8 +21,13 @@ module Components
     end
 
     def view_template
-      div(class: "flex flex-wrap gap-2") do
-        EMOJIS.each { |emoji| render_emoji_button(emoji) }
+      div(
+        id: "reaction_summary_#{@entry.id}",
+        class: "ha-card p-4"
+      ) do
+        div(class: "flex flex-wrap gap-2") do
+          EMOJIS.each { |emoji| render_emoji_button(emoji) }
+        end
       end
     end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
+  include TurboStreamable
+
   before_action :require_authenticated_user!
   before_action :set_trip
   before_action :set_journal_entry
@@ -13,9 +15,14 @@ class CommentsController < ApplicationController
       user: current_user
     )
     case result
-    in Dry::Monads::Success(_comment)
-      redirect_to [@trip, @journal_entry],
-                  notice: "Comment added."
+    in Dry::Monads::Success(comment)
+      respond_to do |format|
+        format.turbo_stream { render_created_comment(comment) }
+        format.html do
+          redirect_to [@trip, @journal_entry],
+                      notice: "Comment added."
+        end
+      end
     in Dry::Monads::Failure(errors)
       redirect_to [@trip, @journal_entry],
                   alert: errors.full_messages.join(", ")
@@ -27,9 +34,19 @@ class CommentsController < ApplicationController
       comment: @comment, params: comment_params
     )
     case result
-    in Dry::Monads::Success(_comment)
-      redirect_to [@trip, @journal_entry],
-                  notice: "Comment updated."
+    in Dry::Monads::Success(comment)
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: stream_replace(
+            dom_id(comment),
+            comment_card_component(comment)
+          )
+        end
+        format.html do
+          redirect_to [@trip, @journal_entry],
+                      notice: "Comment updated."
+        end
+      end
     in Dry::Monads::Failure(errors)
       redirect_to [@trip, @journal_entry],
                   alert: errors.full_messages.join(", ")
@@ -37,9 +54,18 @@ class CommentsController < ApplicationController
   end
 
   def destroy
+    comment_id = dom_id(@comment)
     Comments::Delete.new.call(comment: @comment)
-    redirect_to [@trip, @journal_entry],
-                notice: "Comment deleted.", status: :see_other
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: stream_remove(comment_id)
+      end
+      format.html do
+        redirect_to [@trip, @journal_entry],
+                    notice: "Comment deleted.", status: :see_other
+      end
+    end
   end
 
   private
@@ -66,5 +92,32 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.expect(comment: [:body])
+  end
+
+  def render_created_comment(comment)
+    render turbo_stream: [
+      stream_append(
+        "comments_#{@journal_entry.id}",
+        comment_card_component(comment)
+      ),
+      stream_replace(
+        "comment_form_#{@journal_entry.id}",
+        comment_form_component
+      )
+    ]
+  end
+
+  def comment_card_component(comment)
+    Components::CommentCard.new(
+      trip: @trip, journal_entry: @journal_entry,
+      comment: comment
+    )
+  end
+
+  def comment_form_component
+    Components::CommentForm.new(
+      trip: @trip, journal_entry: @journal_entry,
+      comment: Comment.new
+    )
   end
 end

--- a/app/controllers/concerns/turbo_streamable.rb
+++ b/app/controllers/concerns/turbo_streamable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module TurboStreamable
+  extend ActiveSupport::Concern
+
+  included do
+    include ActionView::RecordIdentifier
+  end
+
+  private
+
+  def phlex_to_html(component)
+    render_to_string(component, layout: false)
+  end
+
+  def stream_replace(target, component)
+    turbo_stream.replace(target, html: phlex_to_html(component))
+  end
+
+  def stream_append(target, component)
+    turbo_stream.append(target, html: phlex_to_html(component))
+  end
+
+  def stream_remove(target)
+    turbo_stream.remove(target)
+  end
+end

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReactionsController < ApplicationController
+  include TurboStreamable
+
   before_action :require_authenticated_user!
   before_action :set_trip
   before_action :set_journal_entry
@@ -13,12 +15,34 @@ class ReactionsController < ApplicationController
       user: current_user,
       emoji: params[:emoji]
     )
-    redirect_to [@trip, @journal_entry]
+    @journal_entry.reload
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: stream_replace(
+          "reaction_summary_#{@journal_entry.id}",
+          reaction_summary_component
+        )
+      end
+      format.html { redirect_to [@trip, @journal_entry] }
+    end
   end
 
   def destroy
     @reaction.destroy!
-    redirect_to [@trip, @journal_entry], status: :see_other
+    @journal_entry.reload
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: stream_replace(
+          "reaction_summary_#{@journal_entry.id}",
+          reaction_summary_component
+        )
+      end
+      format.html do
+        redirect_to [@trip, @journal_entry], status: :see_other
+      end
+    end
   end
 
   private
@@ -42,5 +66,11 @@ class ReactionsController < ApplicationController
   def set_and_authorize_reaction!
     @reaction = @journal_entry.reactions.find(params[:id])
     authorize!(@reaction)
+  end
+
+  def reaction_summary_component
+    Components::ReactionSummary.new(
+      trip: @trip, journal_entry: @journal_entry
+    )
   end
 end

--- a/app/views/journal_entries/show.rb
+++ b/app/views/journal_entries/show.rb
@@ -95,11 +95,9 @@ module Views
       end
 
       def render_reactions
-        div(class: "ha-card p-4") do
-          render Components::ReactionSummary.new(
-            trip: @trip, journal_entry: @entry
-          )
-        end
+        render Components::ReactionSummary.new(
+          trip: @trip, journal_entry: @entry
+        )
       end
 
       def render_comments
@@ -109,13 +107,16 @@ module Views
             plain "Comments"
           end
 
-          comments = @entry.comments.chronological
-                           .includes(:user)
-          comments.each do |comment|
-            render Components::CommentCard.new(
-              trip: @trip, journal_entry: @entry,
-              comment: comment
-            )
+          div(id: "comments_#{@entry.id}",
+              class: "space-y-4") do
+            comments = @entry.comments.chronological
+                             .includes(:user)
+            comments.each do |comment|
+              render Components::CommentCard.new(
+                trip: @trip, journal_entry: @entry,
+                comment: comment
+              )
+            end
           end
 
           render_comment_form

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -51,6 +51,50 @@ RSpec.describe "/trips/:trip_id/journal_entries/:id/comments" do
     end
   end
 
+  describe "turbo_stream responses" do
+    let(:turbo_headers) do
+      { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    it "appends comment and replaces form on create" do
+      post trip_journal_entry_comments_path(trip, entry),
+           params: { comment: { body: "Turbo!" } },
+           headers: turbo_headers
+      expect(response.media_type).to eq(
+        "text/vnd.turbo-stream.html"
+      )
+      expect(response.body).to include("comments_#{entry.id}")
+      expect(response.body).to include(
+        "comment_form_#{entry.id}"
+      )
+    end
+
+    it "replaces comment card on update" do
+      comment = create(:comment, journal_entry: entry,
+                                 user: admin)
+      patch trip_journal_entry_comment_path(
+        trip, entry, comment
+      ), params: { comment: { body: "Updated" } },
+         headers: turbo_headers
+      expect(response.media_type).to eq(
+        "text/vnd.turbo-stream.html"
+      )
+      expect(response.body).to include("<turbo-stream")
+    end
+
+    it "removes comment card on destroy" do
+      comment = create(:comment, journal_entry: entry,
+                                 user: admin)
+      delete trip_journal_entry_comment_path(
+        trip, entry, comment
+      ), headers: turbo_headers
+      expect(response.media_type).to eq(
+        "text/vnd.turbo-stream.html"
+      )
+      expect(response.body).to include("remove")
+    end
+  end
+
   describe "authorization" do
     let(:outsider) { create(:user) }
 

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -29,6 +29,31 @@ RSpec.describe "/trips/:trip_id/journal_entries/:id/reactions" do
     end
   end
 
+  describe "POST create (turbo_stream)" do
+    let(:turbo_headers) do
+      { "Accept" => "text/vnd.turbo-stream.html" }
+    end
+
+    it "returns turbo_stream response" do
+      post trip_journal_entry_reactions_path(trip, entry),
+           params: { emoji: "thumbsup" },
+           headers: turbo_headers
+      expect(response.media_type).to eq(
+        "text/vnd.turbo-stream.html"
+      )
+    end
+
+    it "replaces the reaction summary" do
+      post trip_journal_entry_reactions_path(trip, entry),
+           params: { emoji: "thumbsup" },
+           headers: turbo_headers
+      expect(response.body).to include("<turbo-stream")
+      expect(response.body).to include(
+        "reaction_summary_#{entry.id}"
+      )
+    end
+  end
+
   describe "authorization" do
     let(:outsider) { create(:user) }
 


### PR DESCRIPTION
## Summary

- Add `TurboStreamable` controller concern for rendering Phlex components in Turbo Stream responses (with `layout: false` to prevent full-page nesting)
- **Reactions:** Toggle emoji updates the reaction summary in place via `turbo_stream.replace` — no page reload
- **Comments:** Create appends card + resets form, update replaces card, delete removes card — all via Turbo Streams
- Components (`ReactionSummary`, `CommentForm`) now own their wrapper divs with stable DOM IDs for Turbo targeting
- Journal entry show view adds `id` to comments list container
- UX Review Skill updated with "In-Place Updates (PWA)" checklist to catch this class of issue in the future
- AGENTS.md updated with `GITHUB_TOKEN` note for `gh` CLI auth

## Test plan
- [x] 328 unit/request tests pass (0 failures)
- [x] Lint passes (0 offenses)
- [x] All overcommit hooks pass
- [x] New turbo_stream format specs for reactions (2 tests) and comments (3 tests)
- [x] Verified turbo_stream responses do NOT contain layout HTML (`<!DOCTYPE`, `<html>`)
- [x] Live runtime test: reaction toggle on/off updates in place, no reload
- [x] Live runtime test: comment create appends card + resets form, no reload
- [x] Live runtime test: comment delete removes card, no reload
- [x] URL unchanged across all interactions (verified via `window.location.href`)

Closes #22
Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)