### PR TITLE
UI polish: CSS token fix, component extractions, and visual refinements

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -24,6 +24,7 @@
     --ha-danger-strong: #ef4444;
     --ha-ring: #38bdf8;
     --ha-ring-shadow: rgba(14, 165, 233, 0.25);
+    --ha-surface-hover: #f1f5f9;
     --ha-card-shadow: 0 22px 45px -34px rgba(15, 23, 42, 0.35);
   }
 
@@ -49,6 +50,7 @@
     --ha-danger-strong: #ef4444;
     --ha-ring: #38bdf8;
     --ha-ring-shadow: rgba(14, 165, 233, 0.35);
+    --ha-surface-hover: #1e293b;
     --ha-card-shadow: 0 24px 50px -32px rgba(2, 6, 23, 0.75);
   }
 
@@ -85,6 +87,33 @@
     border: 1px solid var(--ha-card-border);
     background: var(--ha-card);
     box-shadow: var(--ha-card-shadow);
+    transition: transform 150ms ease, box-shadow 150ms ease;
+  }
+
+  .ha-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 26px 50px -30px rgba(15, 23, 42, 0.45);
+  }
+
+  .dark .ha-card:hover {
+    box-shadow: 0 28px 55px -28px rgba(2, 6, 23, 0.85);
+  }
+
+  .ha-overline {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--ha-muted);
+  }
+
+  .ha-card-actions {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    border-top: 1px solid var(--ha-card-border);
+    padding-top: 1rem;
   }
 
   .ha-input {

--- a/app/components/access_request_card.rb
+++ b/app/components/access_request_card.rb
@@ -14,7 +14,7 @@ module Components
       div(id: dom_id(@access_request), class: "ha-card p-6") do
         div(class: "flex items-start justify-between gap-4") do
           div do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Access Request"
             end
             p(class: "mt-2 text-lg font-semibold text-[var(--ha-text)]") { @access_request.email }
@@ -45,7 +45,7 @@ module Components
     end
 
     def render_actions
-      div(class: "mt-5 flex flex-wrap gap-2") do
+      div(class: "ha-card-actions") do
         button_to("Approve", view_context.approve_access_request_path(@access_request),
                   method: :patch, class: "ha-button ha-button-primary")
         button_to("Reject", view_context.reject_access_request_path(@access_request),

--- a/app/components/account_details.rb
+++ b/app/components/account_details.rb
@@ -10,7 +10,7 @@ module Components
       div(class: "ha-card p-6") do
         div(class: "flex flex-wrap items-start justify-between gap-4") do
           div do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") { "Account" }
+            p(class: "ha-overline") { "Account" }
             p(class: "mt-2 text-lg font-semibold text-[var(--ha-text)]") do
               plain(@user.name.presence || "Unnamed")
             end

--- a/app/components/checklist_card.rb
+++ b/app/components/checklist_card.rb
@@ -37,7 +37,7 @@ module Components
     end
 
     def render_actions
-      div(class: "mt-5 flex flex-wrap gap-2") do
+      div(class: "ha-card-actions") do
         link_to(
           "View",
           view_context.trip_checklist_path(@trip, @checklist),

--- a/app/components/comment_card.rb
+++ b/app/components/comment_card.rb
@@ -14,8 +14,11 @@ module Components
 
     def view_template
       div(id: dom_id(@comment),
-          class: "flex gap-3 rounded-lg bg-[var(--ha-surface)] " \
-                 "p-4") do
+          class: "flex gap-3 rounded-xl border " \
+                 "border-[var(--ha-border)] " \
+                 "bg-[var(--ha-surface)] p-4 " \
+                 "transition-colors duration-150 " \
+                 "hover:bg-[var(--ha-surface-hover)]") do
         div(class: "flex-1") do
           render_header
           p(class: "mt-1 text-sm text-[var(--ha-text)]") do
@@ -51,7 +54,8 @@ module Components
             @trip, @entry, @comment
           ),
           method: :delete,
-          class: "text-xs text-red-500 hover:text-red-700",
+          class: "text-xs text-[var(--ha-danger)] " \
+                 "hover:text-[var(--ha-danger-strong)]",
           form: { class: "inline-flex" }
         )
       end

--- a/app/components/invitation_card.rb
+++ b/app/components/invitation_card.rb
@@ -13,7 +13,7 @@ module Components
       div(id: dom_id(@invitation), class: "ha-card p-6") do
         div(class: "flex items-start justify-between gap-4") do
           div do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Invitation"
             end
             p(class: "mt-2 text-lg font-semibold text-[var(--ha-text)]") { @invitation.email }

--- a/app/components/journal_entry_card.rb
+++ b/app/components/journal_entry_card.rb
@@ -54,7 +54,7 @@ module Components
     end
 
     def render_actions
-      div(class: "mt-5 flex flex-wrap gap-2") do
+      div(class: "ha-card-actions") do
         link_to(
           "View",
           view_context.trip_journal_entry_path(@trip, @entry),

--- a/app/components/page_header.rb
+++ b/app/components/page_header.rb
@@ -11,7 +11,7 @@ module Components
     def view_template(&block)
       div(class: "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between") do
         div do
-          p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") { @section }
+          p(class: "ha-overline") { @section }
           h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") { @title }
           p(class: "mt-2 text-sm text-[var(--ha-muted)]") { @subtitle } if @subtitle
         end

--- a/app/components/reaction_summary.rb
+++ b/app/components/reaction_summary.rb
@@ -66,14 +66,15 @@ module Components
 
     def active_class
       "inline-flex items-center rounded-full border " \
-        "border-blue-300 bg-blue-50 px-3 py-1 text-sm " \
-        "dark:border-blue-600 dark:bg-blue-900/30"
+        "border-[var(--ha-accent)]/30 bg-[var(--ha-accent)]/10 " \
+        "px-3 py-1 text-sm transition-all duration-150"
     end
 
     def inactive_class
       "inline-flex items-center rounded-full border " \
         "border-[var(--ha-border)] bg-[var(--ha-surface)] " \
-        "px-3 py-1 text-sm hover:bg-[var(--ha-surface-hover)]"
+        "px-3 py-1 text-sm transition-all duration-150 " \
+        "hover:bg-[var(--ha-surface-hover)]"
     end
   end
 end

--- a/app/components/rodauth_email_auth_request_form.rb
+++ b/app/components/rodauth_email_auth_request_form.rb
@@ -7,7 +7,7 @@ module Components
     def view_template
       div(class: "ha-card p-6 space-y-6") do
         div do
-          p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+          p(class: "ha-overline") do
             plain "Email link"
           end
           h2(class: "mt-2 text-lg font-semibold") { "Send a sign-in link" }

--- a/app/components/rodauth_login_form_footer.rb
+++ b/app/components/rodauth_login_form_footer.rb
@@ -8,7 +8,7 @@ module Components
       return if view_context.rodauth.login_form_footer_links.empty?
 
       div(class: "mt-4 border-t border-[var(--ha-border)] pt-4") do
-        p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+        p(class: "ha-overline") do
           plain "More options"
         end
         div(class: "mt-2 flex flex-wrap gap-3 text-sm text-[var(--ha-muted)]") do

--- a/app/components/trip_card.rb
+++ b/app/components/trip_card.rb
@@ -13,10 +13,7 @@ module Components
       div(id: dom_id(@trip), class: "ha-card p-6") do
         div(class: "flex items-start justify-between gap-4") do
           div do
-            p(class: "text-xs font-semibold uppercase " \
-                     "tracking-[0.2em] text-[var(--ha-muted)]") do
-              plain "Trip"
-            end
+            p(class: "ha-overline") { plain "Trip" }
             p(class: "mt-2 text-lg font-semibold " \
                      "text-[var(--ha-text)]") do
               plain @trip.name
@@ -47,9 +44,9 @@ module Components
     end
 
     def render_actions
-      div(class: "mt-5 flex flex-wrap gap-2") do
+      div(class: "ha-card-actions") do
         link_to("View", view_context.trip_path(@trip),
-                class: "ha-button ha-button-secondary")
+                class: "ha-button ha-button-primary")
         if view_context.allowed_to?(:edit?, @trip)
           link_to("Edit", view_context.edit_trip_path(@trip),
                   class: "ha-button ha-button-secondary")

--- a/app/components/trip_membership_card.rb
+++ b/app/components/trip_membership_card.rb
@@ -53,7 +53,7 @@ module Components
     def render_actions
       return unless view_context.allowed_to?(:destroy?, @membership)
 
-      div(class: "mt-5 flex flex-wrap gap-2") do
+      div(class: "ha-card-actions") do
         button_to(
           "Remove",
           view_context.trip_trip_membership_path(@trip, @membership),

--- a/app/components/user_card.rb
+++ b/app/components/user_card.rb
@@ -13,7 +13,7 @@ module Components
       div(id: dom_id(@user), class: "ha-card p-6") do
         div(class: "flex items-start justify-between gap-4") do
           div do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") { "User" }
+            p(class: "ha-overline") { "User" }
             p(class: "mt-2 text-lg font-semibold text-[var(--ha-text)]") { @user.name }
             div(class: "mt-3 flex items-center gap-2 text-xs text-[var(--ha-muted)]") do
               span(class: "rounded-full bg-[var(--ha-surface-muted)] px-2 py-1") { "Email" }
@@ -34,7 +34,7 @@ module Components
     private
 
     def render_actions
-      div(class: "mt-5 flex flex-wrap gap-2") do
+      div(class: "ha-card-actions") do
         link_to("View", @user, class: "ha-button ha-button-secondary")
         link_to("Edit", view_context.edit_user_path(@user), class: "ha-button ha-button-secondary") if view_context.allowed_to?(:edit?, @user)
       end

--- a/app/views/journal_entries/show.rb
+++ b/app/views/journal_entries/show.rb
@@ -84,11 +84,12 @@ module Views
 
       def render_images
         div(class: "grid grid-cols-2 gap-4 sm:grid-cols-3") do
-          @entry.images.each do |image|
+          @entry.images.each_with_index do |image, index|
             img(
               src: view_context.url_for(image),
-              class: "rounded-xl object-cover",
-              alt: @entry.name
+              class: "aspect-[4/3] w-full rounded-xl " \
+                     "object-cover",
+              alt: "#{@entry.name} - photo #{index + 1}"
             )
           end
         end
@@ -111,11 +112,18 @@ module Views
               class: "space-y-4") do
             comments = @entry.comments.chronological
                              .includes(:user)
-            comments.each do |comment|
-              render Components::CommentCard.new(
-                trip: @trip, journal_entry: @entry,
-                comment: comment
-              )
+            if comments.any?
+              comments.each do |comment|
+                render Components::CommentCard.new(
+                  trip: @trip, journal_entry: @entry,
+                  comment: comment
+                )
+              end
+            else
+              p(class: "text-sm text-[var(--ha-muted)] " \
+                       "italic") do
+                plain "No comments yet."
+              end
             end
           end
 

--- a/app/views/rodauth/create_account.rb
+++ b/app/views/rodauth/create_account.rb
@@ -9,7 +9,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Access"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/email_auth.rb
+++ b/app/views/rodauth/email_auth.rb
@@ -8,7 +8,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Email link"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/login.rb
+++ b/app/views/rodauth/login.rb
@@ -6,7 +6,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Access"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do
@@ -22,7 +22,7 @@ module Views
           div(class: "ha-card p-6 space-y-6") do
             div do
               p(
-                class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]"
+                class: "ha-overline"
               ) { plain "Email" }
               h2(class: "mt-2 text-lg font-semibold") { plain "Continue with email" }
               p(class: "mt-2 text-sm text-[var(--ha-muted)]") do

--- a/app/views/rodauth/logout.rb
+++ b/app/views/rodauth/logout.rb
@@ -8,7 +8,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Account"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/multi_phase_login.rb
+++ b/app/views/rodauth/multi_phase_login.rb
@@ -10,7 +10,7 @@ module Views
 
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Access"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/verify_account.rb
+++ b/app/views/rodauth/verify_account.rb
@@ -9,7 +9,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Verify"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/verify_account_resend.rb
+++ b/app/views/rodauth/verify_account_resend.rb
@@ -9,7 +9,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Verify"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/webauthn_auth.rb
+++ b/app/views/rodauth/webauthn_auth.rb
@@ -11,7 +11,7 @@ module Views
 
         div(class: "ha-card p-6 space-y-6") do
           div do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Passkey"
             end
             h2(class: "mt-2 text-lg font-semibold") { plain "Use a passkey" }

--- a/app/views/rodauth/webauthn_remove.rb
+++ b/app/views/rodauth/webauthn_remove.rb
@@ -9,7 +9,7 @@ module Views
       def view_template
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Security"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/rodauth/webauthn_setup.rb
+++ b/app/views/rodauth/webauthn_setup.rb
@@ -11,7 +11,7 @@ module Views
 
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
-            p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+            p(class: "ha-overline") do
               plain "Security"
             end
             h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do

--- a/app/views/trips/index.rb
+++ b/app/views/trips/index.rb
@@ -31,7 +31,9 @@ module Views
           end
 
           if @trips.any?
-            div(id: "trips", class: "grid gap-4") do
+            div(id: "trips",
+                class: "grid gap-4 sm:grid-cols-2 " \
+                       "lg:grid-cols-3") do
               @trips.each do |trip|
                 render Components::TripCard.new(trip: trip)
               end

--- a/app/views/welcome/home.rb
+++ b/app/views/welcome/home.rb
@@ -18,7 +18,7 @@ module Views
         div(class: "ha-card p-8") do
           div(class: "flex flex-col gap-6 md:flex-row md:items-center md:justify-between") do
             div do
-              p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") do
+              p(class: "ha-overline") do
                 plain "Catalyst Hub"
               end
               h1(class: "mt-2 text-4xl font-semibold tracking-tight sm:text-5xl") { "Welcome home" }
@@ -42,12 +42,12 @@ module Views
 
       def render_users_card
         div(class: "ha-card p-6 ha-rise", style: "animation-delay: 160ms;") do
-          p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") { "Users" }
+          p(class: "ha-overline") { "Users" }
           h2(class: "mt-2 text-2xl font-semibold") { "Stay connected" }
           p(class: "mt-3 text-sm text-[var(--ha-muted)]") do
             plain "Manage who owns and contributes to the latest updates."
           end
-          div(class: "mt-5 flex flex-wrap gap-2") do
+          div(class: "ha-card-actions") do
             link_to("New user", view_context.new_user_path, class: "ha-button ha-button-primary")
             link_to("Browse", view_context.users_path, class: "ha-button ha-button-secondary")
           end
@@ -64,12 +64,12 @@ module Views
 
       def render_passkey_card
         div(class: "ha-card p-6 ha-rise", style: "animation-delay: 240ms;") do
-          p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") { "Security" }
+          p(class: "ha-overline") { "Security" }
           h2(class: "mt-2 text-2xl font-semibold") { "Add a passkey" }
           p(class: "mt-3 text-sm text-[var(--ha-muted)]") do
             plain "Register a passkey per device for faster, safer sign-ins."
           end
-          div(class: "mt-5 flex flex-wrap gap-2") do
+          div(class: "ha-card-actions") do
             link_to("Add passkey", view_context.rodauth.webauthn_setup_path,
                     class: "ha-button ha-button-primary")
             if view_context.rodauth.webauthn_setup?
@@ -82,12 +82,12 @@ module Views
 
       def render_signin_card
         div(class: "ha-card p-6 ha-rise", style: "animation-delay: 240ms;") do
-          p(class: "text-xs font-semibold uppercase tracking-[0.2em] text-[var(--ha-muted)]") { "Access" }
+          p(class: "ha-overline") { "Access" }
           h2(class: "mt-2 text-2xl font-semibold") { "Private application" }
           p(class: "mt-3 text-sm text-[var(--ha-muted)]") do
             plain "This is an invite-only app. Request access or sign in if you already have an account."
           end
-          div(class: "mt-5 flex flex-wrap gap-2") do
+          div(class: "ha-card-actions") do
             link_to("Request Access", view_context.new_access_request_path,
                     class: "ha-button ha-button-primary")
             link_to("Sign in", view_context.rodauth.login_path,


### PR DESCRIPTION
## Summary

Addresses findings from the ui-polish skill review across journal entry show page, trip cards, and design system.

### Bug fix
- Define missing `--ha-surface-hover` CSS variable (was referenced in ReactionSummary but never defined — hover state was silently broken)

### CSS component extractions (27 files, net reduction in inline utilities)
- **`ha-overline`**: Extracted micro-label pattern (22 inline occurrences → 1 CSS class)
- **`ha-card-actions`**: Extracted card footer with border-top divider (8 inline occurrences → 1 CSS class)
- **`ha-card:hover`**: Added lift + shadow intensification on hover (benefits all cards project-wide)

### Design token alignment
- ReactionSummary: hardcoded `blue-*` → `--ha-accent` tokens
- CommentCard: hardcoded `text-red-500` → `--ha-danger` token
- CommentCard: `rounded-lg` → `rounded-xl` (matches project radius language)

### Visual refinements
- Reaction pills: added `transition-all duration-150` for smooth hover
- CommentCard: added border + hover background transition for light-mode visibility
- Journal entry images: `aspect-[4/3]` for consistent grid, indexed alt text
- Trips index: responsive grid (`sm:grid-cols-2 lg:grid-cols-3`)
- Trip card: "View" promoted to `ha-button-primary`
- Comments: empty state when no comments exist

## Test plan
- [x] 328 tests pass (0 failures)
- [x] Lint passes (0 offenses)
- [x] All overcommit hooks pass

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)