### PR TITLE
Fix passkey management blocked for email-auth users

### DIFF
--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -35,6 +35,10 @@ class RodauthMain < Rodauth::Rails::Auth
       require_bcrypt? false
 
       auth_class_eval do
+        def two_factor_authentication_setup?
+          false
+        end
+
         def get_password_hash
           nil
         end


### PR DESCRIPTION
## Summary
- Override `two_factor_authentication_setup?` to return `false` in `auth_class_eval`
- This app uses email_auth and webauthn as **alternative first factors**, not first + second
- The `two_factor_base` feature is only loaded because `webauthn` depends on it
- Without this fix, email-auth users get "You need to authenticate via an additional factor" when trying to add/manage passkeys

## Test plan
- [x] All 479 non-system specs pass
- [x] All 14 system specs pass
- [x] Lint passes (RuboCop + ERB Lint)
- [x] All overcommit hooks pass
- [x] Docker rebuild + health check passes
- [x] Visual verification at https://catalyst.workeverywhere.docker

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)