### PR TITLE
Phase 17: Passkey UX round 2 — names, mutex, /trips redirect

### DIFF
--- a/app/components/sidebar.rb
+++ b/app/components/sidebar.rb
@@ -197,12 +197,6 @@ module Components
         icon: Components::Icons::SignIn.new,
         delay: "300ms"
       )
-      render Components::NavItem.new(
-        path: view_context.rodauth.create_account_path,
-        label: "Create account",
-        icon: Components::Icons::CreateAccount.new,
-        delay: "340ms"
-      )
     end
 
     def render_status_footer

--- a/app/components/sidebar.rb
+++ b/app/components/sidebar.rb
@@ -161,21 +161,20 @@ module Components
         icon: Components::Icons::Person.new,
         delay: "260ms"
       )
-      render Components::NavItem.new(
-        path: view_context.rodauth.webauthn_setup_path,
-        label: "Add passkey",
-        icon: Components::Icons::Key.new,
-        delay: "300ms"
-      )
-      if view_context.rodauth.webauthn_setup?
-        render Components::NavItem.new(
-          path: view_context.rodauth.webauthn_remove_path,
-          label: "Manage passkeys",
-          icon: Components::Icons::KeyRemove.new,
-          delay: "340ms"
-        )
-      end
+      render Components::NavItem.new(**passkey_nav_attrs)
       render_logout_button
+    end
+
+    def passkey_nav_attrs
+      if view_context.rodauth.webauthn_setup?
+        { path: view_context.rodauth.webauthn_remove_path,
+          label: "Manage passkeys",
+          icon: Components::Icons::KeyRemove.new, delay: "300ms" }
+      else
+        { path: view_context.rodauth.webauthn_setup_path,
+          label: "Add passkey",
+          icon: Components::Icons::Key.new, delay: "300ms" }
+      end
     end
 
     def render_logout_button

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -113,6 +113,13 @@ class RodauthMain < Rodauth::Rails::Auth
           nil
         end
 
+        # Drop the "Create a New Account" link from the /login footer.
+        # Account creation is invitation-only; surfacing the public path
+        # here leads to a dead end.
+        def login_form_footer_links
+          super.reject { |_, link, _| link == create_account_path }
+        end
+
         def webauthn_key_insert_hash(webauthn_credential)
           super.merge(name: resolve_passkey_name(webauthn_credential))
         end

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -108,6 +108,29 @@ class RodauthMain < Rodauth::Rails::Auth
           nil
         end
 
+        def webauthn_key_insert_hash(webauthn_credential)
+          super.merge(name: resolve_passkey_name(webauthn_credential))
+        end
+
+        def resolve_passkey_name(webauthn_credential)
+          submitted = param_or_nil("passkey_name").to_s.strip
+          return submitted[0, 80] if submitted.present?
+
+          aaguid = extract_aaguid(webauthn_credential)
+          Webauthn::AaguidLookup.lookup(aaguid) ||
+            Webauthn::NameSuggester.from_user_agent(request.user_agent)
+        end
+
+        def extract_aaguid(webauthn_credential)
+          webauthn_credential
+            .response
+            .authenticator_data
+            .attested_credential_data
+            &.aaguid
+        rescue StandardError
+          nil
+        end
+
         def before_create_account
           super
           validate_invitation_token

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -65,7 +65,12 @@ class RodauthMain < Rodauth::Rails::Auth
       # already proves the user controls that inbox, so we auto-verify,
       # skip the verification email, and auto-log them in.
       create_account_autologin? { param_or_nil("invitation_token").present? }
-      create_account_redirect { "/" }
+
+      # Post-auth destination is the trips index — the actual app surface.
+      # "/" stays reachable from the sidebar Overview link.
+      login_redirect "/trips"
+      create_account_redirect { "/trips" }
+      webauthn_setup_redirect "/trips"
 
       # Rodauth's :login feature calls account_from_login BEFORE
       # before_login_attempt, so that hook cannot intercept a missing

--- a/app/misc/webauthn/aaguid_lookup.rb
+++ b/app/misc/webauthn/aaguid_lookup.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Webauthn
+  # AAGUID → authenticator name.
+  #
+  # Curated subset of the public
+  # https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+  # registry — only the entries most likely to show up on the passkeys
+  # our user base actually uses. Add entries as they come up.
+  module AaguidLookup
+    REGISTRY = {
+      "adce0002-35bc-c60a-648b-0b25f1f05503" => "Chrome on Mac",
+      "dd4ec289-e01d-41c9-bb89-70fa845d4bf2" => "iCloud Keychain (iOS)",
+      "fbfc3007-154e-4ecc-8c0b-6e020557d7bd" => "iCloud Keychain",
+      "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4" => "Google Password Manager",
+      "08987058-cadc-4b81-b6e1-30de50dcbe96" => "Windows Hello",
+      "9ddd1817-af5a-4672-a2b9-3e3dd95000a9" => "Windows Hello",
+      "b84e4048-15dc-4dd0-8640-f4f60813c8af" => "1Password",
+      "bada5566-a7aa-401f-bd96-45619a55120d" => "1Password",
+      "d548826e-79b4-db40-a3d8-11116f7e8349" => "Bitwarden",
+      "fdb141b2-5d84-443e-8a35-4698c205a502" => "KeePassXC",
+      "cc45f64e-52a2-451b-831a-4edd8022a202" => "ToothPic Passkey Provider",
+      "b5397666-4885-aa6b-cebf-e52262a439a2" => "Chromium"
+    }.freeze
+
+    module_function
+
+    def lookup(aaguid)
+      return nil if aaguid.blank?
+
+      key = aaguid.to_s.downcase
+      REGISTRY[key]
+    end
+  end
+end

--- a/app/misc/webauthn/name_suggester.rb
+++ b/app/misc/webauthn/name_suggester.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Webauthn
+  module NameSuggester
+    DEFAULT = "Passkey"
+    MAX_LENGTH = 60
+
+    module_function
+
+    def from_user_agent(user_agent)
+      label = detect_label(user_agent.to_s)
+      label.to_s[0, MAX_LENGTH]
+    end
+
+    PATTERNS = [
+      [/iPhone/i,     ->(_) { "iPhone" }],
+      [/iPad/i,       ->(_) { "iPad" }],
+      [/Macintosh/i,  ->(ua) { mac_label(ua) }],
+      [/Android/i,    ->(ua) { android_label(ua) }],
+      [/Windows NT/i, ->(_) { "Windows PC" }],
+      [/CrOS/i,       ->(_) { "Chromebook" }],
+      [/Linux/i,      ->(_) { "Linux device" }]
+    ].freeze
+
+    def detect_label(user_agent)
+      return DEFAULT if user_agent.empty?
+
+      _, resolver = PATTERNS.find { |pattern, _| user_agent.match?(pattern) }
+      resolver ? resolver.call(user_agent) : DEFAULT
+    end
+
+    def mac_label(user_agent)
+      return "Mac (Edge)" if user_agent.match?(%r{Edg/}i)
+      return "Mac (Chrome)" if user_agent.match?(/Chrome/i)
+      return "Mac (Firefox)" if user_agent.match?(/Firefox/i)
+      return "Mac (Safari)" if user_agent.match?(/Safari/i)
+
+      "Mac"
+    end
+
+    def android_label(user_agent)
+      return "Pixel phone" if user_agent.match?(/Pixel/i)
+
+      "Android phone"
+    end
+  end
+end

--- a/app/views/rodauth/webauthn_remove.rb
+++ b/app/views/rodauth/webauthn_remove.rb
@@ -5,84 +5,129 @@ module Views
     class WebauthnRemove < Views::Base
       include Phlex::Rails::Helpers::FormWith
       include Phlex::Rails::Helpers::ContentTag
+      include Phlex::Rails::Helpers::LinkTo
 
       def view_template
         div(class: "space-y-8") do
-          div(class: "ha-card p-8") do
-            p(class: "ha-overline") do
-              plain "Security"
-            end
-            h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do
-              plain "Manage passkeys"
-            end
-            p(class: "mt-3 text-sm text-[var(--ha-muted)]") do
-              plain "Remove a passkey that you no longer use."
-            end
-          end
-
+          render_hero
           render Components::RodauthFlash.new
+          render_add_another_card
+          render_remove_form
+        end
+      end
 
-          div(class: "ha-card p-6 space-y-6") do
-            form_with(
-              url: view_context.rodauth.webauthn_remove_path,
-              method: :post,
-              id: "webauthn-remove-form",
-              data: { turbo: false },
-              class: "space-y-6"
-            ) do |form|
-              raw safe(view_context.rodauth.webauthn_remove_additional_form_tags.to_s)
+      private
 
-              div(class: "flex flex-col gap-3") do
-                view_context.rodauth.account_webauthn_usage.each do |id, last_use|
-                  formatted_use = if last_use.is_a?(Time)
-                                    last_use.strftime(view_context.rodauth.strftime_format)
-                                  else
-                                    last_use
-                                  end
-
-                  remove_error = view_context.rodauth.field_error(
-                    view_context.rodauth.webauthn_remove_param
-                  )
-                  aria_attrs = if remove_error
-                                 { invalid: true, describedby: "webauthn_remove_error_message" }
-                               else
-                                 {}
-                               end
-
-                  label(
-                    for: "webauthn-remove-#{id}",
-                    class: "flex items-center gap-3 rounded-xl border " \
-                           "border-[var(--ha-border)] bg-[var(--ha-surface-muted)] " \
-                           "px-3 py-2 text-sm text-[var(--ha-text)]"
-                  ) do
-                    form.radio_button(
-                      view_context.rodauth.webauthn_remove_param,
-                      id,
-                      id: "webauthn-remove-#{id}",
-                      class: "h-4 w-4",
-                      aria: aria_attrs
-                    )
-                    span { plain "Last used: #{formatted_use}" }
-                  end
-                end
-              end
-
-              remove_error = view_context.rodauth.field_error(
-                view_context.rodauth.webauthn_remove_param
-              )
-              if remove_error
-                span(
-                  class: "block text-xs text-red-500",
-                  id: "webauthn_remove_error_message"
-                ) { remove_error }
-              end
-
-              form.submit(
-                view_context.rodauth.webauthn_remove_button,
-                class: "ha-button ha-button-danger w-full"
-              )
-            end
+      def render_hero
+        div(class: "ha-card p-8") do
+          p(class: "ha-overline") { plain "Security" }
+          h1(class: "mt-2 text-3xl font-semibold tracking-tight sm:text-4xl") do
+            plain "Manage passkeys"
           end
+          p(class: "mt-3 text-sm text-[var(--ha-muted)]") do
+            plain "Remove a passkey that you no longer use."
+          end
+        end
+      end
+
+      def render_add_another_card
+        div(class: "ha-card p-6") do
+          h2(class: "text-lg font-semibold") { plain "Add another passkey" }
+          p(class: "mt-2 text-sm text-[var(--ha-muted)]") do
+            plain "Register another device for faster, safer sign-ins."
+          end
+          div(class: "mt-4") do
+            link_to(
+              "Add passkey",
+              view_context.rodauth.webauthn_setup_path,
+              class: "ha-button ha-button-primary"
+            )
+          end
+        end
+      end
+
+      def render_remove_form
+        div(class: "ha-card p-6 space-y-6") do
+          form_with(
+            url: view_context.rodauth.webauthn_remove_path,
+            method: :post,
+            id: "webauthn-remove-form",
+            data: { turbo: false },
+            class: "space-y-6"
+          ) do |form|
+            raw safe(view_context.rodauth.webauthn_remove_additional_form_tags.to_s)
+
+            div(class: "flex flex-col gap-3") do
+              passkey_rows.each { |row| render_passkey_row(form, row) }
+            end
+
+            render_remove_error
+
+            form.submit(
+              view_context.rodauth.webauthn_remove_button,
+              class: "ha-button ha-button-danger w-full"
+            )
+          end
+        end
+      end
+
+      def render_passkey_row(form, row)
+        label(
+          for: "webauthn-remove-#{row[:id]}",
+          class: "flex items-center gap-3 rounded-xl border " \
+                 "border-[var(--ha-border)] bg-[var(--ha-surface-muted)] " \
+                 "px-3 py-2 text-sm text-[var(--ha-text)]"
+        ) do
+          form.radio_button(
+            view_context.rodauth.webauthn_remove_param,
+            row[:id],
+            id: "webauthn-remove-#{row[:id]}",
+            class: "h-4 w-4",
+            aria: radio_aria_attrs
+          )
+          span(class: "font-medium") { plain row[:name] }
+          span(class: "text-[var(--ha-muted)]") do
+            plain " — Last used: #{row[:last_use]}"
+          end
+        end
+      end
+
+      def render_remove_error
+        return unless remove_error
+
+        span(
+          class: "block text-xs text-red-500",
+          id: "webauthn_remove_error_message"
+        ) { remove_error }
+      end
+
+      def radio_aria_attrs
+        return {} unless remove_error
+
+        { invalid: true, describedby: "webauthn_remove_error_message" }
+      end
+
+      def remove_error
+        return @remove_error if defined?(@remove_error)
+
+        @remove_error = view_context.rodauth.field_error(
+          view_context.rodauth.webauthn_remove_param
+        )
+      end
+
+      def passkey_rows
+        rodauth = view_context.rodauth
+        fmt = rodauth.strftime_format
+        sql = "SELECT webauthn_id, last_use, name FROM user_webauthn_keys " \
+              "WHERE user_id = ? ORDER BY last_use DESC"
+        rows = ActiveRecord::Base.connection
+                                 .exec_query(sql, "Passkeys", [rodauth.account_id])
+        rows.map do |row|
+          last_use = row["last_use"]
+          parsed = last_use.is_a?(Time) ? last_use : Time.zone.parse(last_use.to_s)
+          { id: row["webauthn_id"],
+            name: row["name"].presence || "Passkey",
+            last_use: parsed ? parsed.strftime(fmt) : "Never" }
         end
       end
     end

--- a/app/views/rodauth/webauthn_setup.rb
+++ b/app/views/rodauth/webauthn_setup.rb
@@ -8,6 +8,9 @@ module Views
 
       def view_template
         cred = view_context.rodauth.new_webauthn_credential
+        suggested = Webauthn::NameSuggester.from_user_agent(
+          view_context.request.user_agent
+        )
 
         div(class: "space-y-8") do
           div(class: "ha-card p-8") do
@@ -50,6 +53,8 @@ module Views
                 aria: { hidden: "true" }
               )
 
+              render_name_field(form, suggested)
+
               div(id: "webauthn-setup-button") do
                 form.submit(
                   view_context.rodauth.webauthn_setup_button,
@@ -64,6 +69,29 @@ module Views
           view_context.rodauth.webauthn_setup_js_path,
           extname: false
         )
+      end
+
+      private
+
+      def render_name_field(form, suggested)
+        div(class: "space-y-2") do
+          form.label(
+            :passkey_name,
+            "Passkey name",
+            class: "text-sm font-medium text-[var(--ha-on-surface-variant)]"
+          )
+          form.text_field(
+            :passkey_name,
+            value: suggested,
+            maxlength: 60,
+            autocomplete: "off",
+            placeholder: "e.g. Mac fingerprint, Pixel phone, Bitwarden",
+            class: "ha-input"
+          )
+          p(class: "text-xs text-[var(--ha-muted)]") do
+            plain "Give this device a name you'll recognise later."
+          end
+        end
       end
     end
   end

--- a/app/views/shared/unauthorized.rb
+++ b/app/views/shared/unauthorized.rb
@@ -17,11 +17,6 @@ module Views
           end
           div(class: "mt-5 flex flex-wrap gap-3") do
             link_to("Sign in", view_context.rodauth.login_path, class: "ha-button ha-button-primary")
-            link_to(
-              "Create account",
-              view_context.rodauth.create_account_path,
-              class: "ha-button ha-button-secondary"
-            )
           end
         end
       end

--- a/app/views/welcome/home.rb
+++ b/app/views/welcome/home.rb
@@ -130,9 +130,10 @@ module Views
       end
 
       def render_info_cards
-        div(class: "grid gap-6 md:grid-cols-2") do
-          render_users_card if view_context.allowed_to?(:index?, User)
-          render_passkey_card
+        return unless view_context.allowed_to?(:index?, User)
+
+        div(class: "mx-auto w-full max-w-md") do
+          render_users_card
         end
       end
 
@@ -150,28 +151,6 @@ module Views
                     class: "ha-button ha-button-primary")
             link_to("Browse", view_context.users_path,
                     class: "ha-button ha-button-secondary")
-          end
-        end
-      end
-
-      def render_passkey_card
-        div(class: "ha-card p-6 ha-rise", style: "animation-delay: 240ms;") do
-          p(class: "ha-overline") { "Security" }
-          h2(class: "mt-2 font-headline text-2xl font-bold") do
-            plain "Add a passkey"
-          end
-          p(class: "mt-3 text-sm text-[var(--ha-on-surface-variant)]") do
-            plain "Register a passkey per device for faster, safer sign-ins."
-          end
-          div(class: "mt-6 flex flex-wrap gap-3") do
-            link_to("Add passkey",
-                    view_context.rodauth.webauthn_setup_path,
-                    class: "ha-button ha-button-primary")
-            if view_context.rodauth.webauthn_setup?
-              link_to("Manage passkeys",
-                      view_context.rodauth.webauthn_remove_path,
-                      class: "ha-button ha-button-secondary")
-            end
           end
         end
       end

--- a/db/migrate/20260419134652_add_name_to_user_webauthn_keys.rb
+++ b/db/migrate/20260419134652_add_name_to_user_webauthn_keys.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNameToUserWebauthnKeys < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_webauthn_keys, :name, :string, limit: 80
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_19_134652) do
   create_table "access_requests", id: uuid, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
@@ -239,6 +239,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_120000) do
 
   create_table "user_webauthn_keys", primary_key: ["user_id", "webauthn_id"], force: :cascade do |t|
     t.datetime "last_use", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.string "name", limit: 80
     t.string "public_key", null: false
     t.integer "sign_count", null: false
     t.string "user_id", limit: 36

--- a/prompts/Phase 17 - Steps.md
+++ b/prompts/Phase 17 - Steps.md
@@ -18,6 +18,10 @@ Flight recorder for Phase 17. Append-only.
   - In Progress → In Review (PR open)
   - In Review → Done (merge)
 
+## 9. PR
+
+- **PR:** [joel/trip#113](https://github.com/joel/trip/pull/113) — "Phase 17: Passkey UX round 2 — names, mutex, /trips redirect"
+
 ## 4. Branch
 
 - **Branch:** `feature/phase17-passkey-ux`

--- a/prompts/Phase 17 - Steps.md
+++ b/prompts/Phase 17 - Steps.md
@@ -1,0 +1,23 @@
+# Phase 17 — Onboarding Improvements Round 2 (Passkey UX) — Steps
+
+Flight recorder for Phase 17. Append-only.
+
+## 1. Issue
+
+- **Issue:** [joel/trip#112](https://github.com/joel/trip/issues/112) — "Phase 17: Onboarding Improvements — Round 2 (Passkey UX)"
+- **Plan:** `prompts/Phase 17 Onboarding Improvements Round 2.md`
+- **Status:** User approved the plan on 2026-04-19, including the three open questions:
+  - Global `login_redirect` change (admins + invited users both land on `/trips`) — **approved**.
+  - Deferring edit-name flow for legacy passkeys to a later phase — **approved**.
+  - Direct-SQL on `/webauthn-remove` rather than merge-in-Ruby — **approved**.
+
+## 2. Kanban
+
+- The local `gh` token is missing `read:project` / `project` scopes — Kanban moves need to be made manually (or after `gh auth refresh -s project`). Recording the intended transitions so they can be applied after the fact:
+  - Backlog → Ready → In Progress (start of work)
+  - In Progress → In Review (PR open)
+  - In Review → Done (merge)
+
+## 4. Branch
+
+- **Branch:** `feature/phase17-passkey-ux`

--- a/prompts/Phase 17 - Steps.md
+++ b/prompts/Phase 17 - Steps.md
@@ -21,3 +21,34 @@ Flight recorder for Phase 17. Append-only.
 ## 4. Branch
 
 - **Branch:** `feature/phase17-passkey-ux`
+
+## 7. Commits
+
+| SHA | Subject | Notes |
+|-----|---------|-------|
+| `3b4b9fe` | Add Phase 17 plan and steps scaffolding | Doc-only, `[skip ci]`. |
+| `e7b4844` | Remove passkey panel from logged-in home | Task 1. Info cards now single-column, admin-only. |
+| `4e94977` | Make sidebar passkey link mutually exclusive | Task 2. Extracts `passkey_nav_attrs` to keep Metrics/ClassLength happy. |
+| `51801e8` | Add name column to user_webauthn_keys | Task 4a. Nullable string(80) additive migration. |
+| `24bf033` | Collect passkey name on setup and persist it | Task 4b/c/d. `webauthn_key_insert_hash` override, UA + AAGUID fallbacks. |
+| `5a70b0d` | Show passkey names and Add-another CTA on /webauthn-remove | Task 3 + 4e. Direct-SQL via `exec_query` with bound `account_id`. |
+| `ec35fb1` | Land post-auth flows on /trips instead of home | Task 5. `login_redirect`/`create_account_redirect`/`webauthn_setup_redirect`. |
+
+## 8. Runtime verification
+
+Browser walk via `agent-browser` against `https://catalyst.workeverywhere.docker/`:
+
+- Logged-out home still shows only the "Request an invitation" card.
+- Sign-in via email-auth lands on **/trips** (login_redirect applied).
+- Logged-in home: no "Add a passkey" card; "Stay connected" users card
+  centred alone.
+- Sidebar with ≥1 passkey: shows **Manage passkeys**, hides **Add passkey**.
+- `/webauthn-remove`: top card is "Add another passkey" with a primary
+  link to `/webauthn-setup`; legacy passkey row renders as
+  `"Passkey — Last used: 2026-04-18 13:48:20"` (name column NULL).
+- `/webauthn-setup`: "Passkey name" input visible, pre-filled with
+  `"Linux device"` (UA-derived suggestion from the browser's agent).
+- `/account`, `/users`, `/trips` all render cleanly.
+
+Security gates clean: `brakeman` 0 warnings, `bundle-audit` 0
+vulnerabilities.

--- a/prompts/Phase 17 Onboarding Improvements Round 2.md
+++ b/prompts/Phase 17 Onboarding Improvements Round 2.md
@@ -1,0 +1,515 @@
+# Phase 17: Onboarding Improvements — Round 2 (Passkey UX)
+
+**Status:** Draft
+**Date:** 2026-04-19
+**Confidence Score:** 8/10 (all touch points are in our own code; the only open question is the exact quality of the auto-suggested passkey title, which depends on the User-Agent string and the AAGUID visibility — both fall back gracefully to a user-editable text field)
+
+---
+
+## 1. Context
+
+Follow-up to [Phase 16 — Onboarding Improvements](https://github.com/joel/trip/pull/103). Phase 16 cleaned up the logged-out entry flow; Phase 17 cleans up the **logged-in passkey surface** that the invited user first sees.
+
+**Observations from live use at `https://catalyst.workeverywhere.docker/`:**
+
+1. The logged-in home page shows a large "Security / Add a passkey" card (`render_passkey_card` in `app/views/welcome/home.rb:157`). This card is the very first thing an invited user sees after signing up — before they ever see a trip. It's visual noise for anyone who already has a passkey and friction for anyone who doesn't care to add one right now.
+
+2. The sidebar shows **both** "Add passkey" and "Manage passkeys" at the same time once any passkey is registered (`app/components/sidebar.rb:164-177`). "Add passkey" is the odd one out: it should disappear once a user has at least one passkey and reappear only from inside the manage-passkeys screen.
+
+3. The `/webauthn-remove` screen currently only lists existing passkeys with a "Last used: …" label. Users can't tell a 1Password entry from a Mac-fingerprint entry from a Pixel-phone entry — they're all identical timestamps. Passkeys need a human-readable **title**, ideally auto-suggested at registration time and editable by the user.
+
+4. The `/webauthn-remove` screen has no way to add another passkey — the user has to hunt for the sidebar link. Once "Add passkey" is hidden from the sidebar (point 2), the manage screen must become the single place to add a new one.
+
+5. On successful sign-in the app lands on `/` (Rodauth's default `login_redirect`). For a logged-in user with at least one trip, the meaningful destination is `/trips`, not the passkey-heavy home. Per the user's ask: **"Once connected the user must be redirected to `/trips` instead of having the Passkey Panel that mean nothing."**
+
+Passkeys stay optional — none of the changes here gate trip access on having a passkey. This phase is pure information-architecture + one small data addition (the passkey name column).
+
+---
+
+## 2. Reference Documentation
+
+| Resource | URL |
+|----------|-----|
+| Rodauth WebAuthn Feature | https://rodauth.jeremyevans.net/rdoc/files/doc/webauthn_rdoc.html |
+| Rodauth WebAuthn Setup (auth-value methods) | https://rodauth.jeremyevans.net/rdoc/files/doc/webauthn_rdoc.html#label-Auth+Value+Methods |
+| `webauthn_keys_account_id_column` / `webauthn_keys_table` | https://rodauth.jeremyevans.net/rdoc/files/doc/webauthn_rdoc.html |
+| `account_webauthn_usage` internals | https://github.com/jeremyevans/rodauth/blob/master/lib/rodauth/features/webauthn.rb |
+| `webauthn-ruby` gem (AAGUID on credential) | https://github.com/cedarcode/webauthn-ruby |
+| FIDO Alliance AAGUID registry | https://github.com/passkeydeveloper/passkey-authenticator-aaguids |
+| Rails 8.1 Guides — Migrations (add_column) | https://guides.rubyonrails.org/active_record_migrations.html |
+| Phlex Rails Components | https://www.phlex.fun/rails |
+| Tailwind CSS 4 docs | https://tailwindcss.com/docs |
+
+---
+
+## 3. Scope
+
+### What this phase changes
+
+1. **Remove the homepage passkey panel.** `render_passkey_card` and its call-site in `render_info_cards` come out of `app/views/welcome/home.rb`.
+2. **Sidebar is mutually exclusive.** Show "Add passkey" **or** "Manage passkeys", never both. The predicate is `view_context.rodauth.webauthn_setup?` (true when the user has ≥1 passkey on file).
+3. **Add an "Add another passkey" CTA on `/webauthn-remove`.** The manage screen becomes the canonical place to register additional passkeys.
+4. **Passkey titles.** New column `user_webauthn_keys.name` (nullable). The setup form collects a title, pre-filled with a sensible auto-suggestion derived from the incoming User-Agent and the AAGUID of the credential when available. The remove screen displays `name — Last used: <ts>` and falls back to `"Passkey — Last used: <ts>"` for legacy rows where `name IS NULL`.
+5. **Post-sign-in redirect.** `login_redirect` and `webauthn_setup_redirect` both resolve to `/trips`. `create_account_redirect` for invited signups also resolves to `/trips` (previously `/`).
+
+### What this phase does NOT change
+
+- The `/webauthn-setup` screen stays at the same URL; only its form gains a `name` field.
+- The `/webauthn-auth` (sign-in via passkey) screen is untouched.
+- WebAuthn autofill on `/login` is untouched.
+- The Rodauth config for origin / RP ID / RP name is untouched.
+- No change to invitation, access-request, verify-account, or email-auth flows.
+- No change to the schema of `users`, `invitations`, `access_requests`, or any Rodauth-owned table other than the single `add_column :user_webauthn_keys, :name`.
+- No migration of existing passkey rows — legacy rows show "Passkey" as their label until the user re-registers or we add an edit flow (out of scope here).
+- No change to the policies layer.
+
+---
+
+## 4. Existing Codebase Context
+
+### Relevant files
+
+| File | Current behaviour |
+|------|------------------|
+| `app/views/welcome/home.rb:132-177` | `render_info_cards` renders a 2-col grid with `render_users_card` and `render_passkey_card`. The passkey card links to `webauthn_setup_path` and conditionally to `webauthn_remove_path` when `rodauth.webauthn_setup?` is true. |
+| `app/components/sidebar.rb:157-178` | `render_logged_in_links` always renders "Add passkey" and additionally renders "Manage passkeys" when `rodauth.webauthn_setup?` is true. |
+| `app/views/rodauth/webauthn_remove.rb` | Lists each key via `account_webauthn_usage.each do |id, last_use|`, labelled only with `"Last used: #{formatted_use}"`. No add-new-passkey CTA. |
+| `app/views/rodauth/webauthn_setup.rb` | Renders a minimal form with challenge + challenge HMAC hidden fields and a single submit button. No name input. |
+| `app/misc/rodauth_main.rb:7-220` | Configures the Rodauth auth class. `logout_redirect "/"` is set; `login_redirect` and `webauthn_setup_redirect` use Rodauth defaults (`/`). `create_account_redirect { "/" }` at line 68. |
+| `db/schema.rb:240-247` | `user_webauthn_keys` has compound PK `(user_id, webauthn_id)` plus `last_use`, `public_key`, `sign_count`. No `name` column. |
+| `spec/system/webauthn_autofill_spec.rb` + `spec/requests/webauthn_autofill_spec.rb` | Existing coverage of the autofill feature — not affected by this phase but should stay green. |
+
+### Rodauth internals worth citing
+
+- **`webauthn_setup?`** — auth-value method returning true when the account has ≥1 row in `user_webauthn_keys`. Already used in both sidebar and home.
+- **`account_webauthn_usage`** — returns `{ webauthn_id => last_use_timestamp, ... }` for the current account. Used to render the remove list. We'll replace it with a direct query so we can also surface the name column.
+- **`add_webauthn_credential(credential)`** — inserts the new row into `user_webauthn_keys`. It ignores unknown columns, so the `name` value needs to be written in a hook after the row is inserted (simplest path: `after_webauthn_setup` hook that updates the just-inserted row by `webauthn_id`).
+- **`webauthn_setup_redirect`** — auth-value method, defaults to `require_login_redirect` → `/`. Overridable to `/trips`.
+- **`login_redirect`** — auth-value method, defaults to `/`. Overridable to `/trips`.
+- **`after_webauthn_setup`** — post-insert hook. `webauthn_id` is available here as the credential ID string; we can use it as the row key to write `name`.
+- **Param access** — `param_or_nil("passkey_name")` inside the Rodauth auth class reads the submitted form field.
+
+### Auto-suggested title derivation
+
+The suggestion is a best-effort hint computed once at GET `/webauthn-setup` and shown in the input's `placeholder` and as the `value` (user editable). Two inputs:
+
+1. **AAGUID**: the `webauthn-ruby` gem exposes `credential.response.authenticator_data.attested_credential_data.aaguid` after attestation. Mapped against the public [passkey-authenticator-aaguids](https://github.com/passkeydeveloper/passkey-authenticator-aaguids) registry, we get strings like `"Apple iCloud Keychain"`, `"1Password"`, `"Bitwarden"`, `"Google Password Manager"`, `"Windows Hello"`. **However** — the AAGUID isn't available until the browser returns the attestation, i.e. after the user taps the submit button. So this path fills the name **in the after-setup hook on the server**, not as a pre-filled placeholder.
+
+2. **User-Agent**: available on GET `/webauthn-setup`. We parse it into a coarse label:
+   - `"iPhone"` / `"iPad"` → `"iPhone"` / `"iPad"`
+   - `"Macintosh"` + Safari → `"Mac (Safari)"`, + Chrome → `"Mac (Chrome)"`, etc.
+   - `"Android"` + known device name → `"<device>"`, else `"Android phone"`
+   - `"Windows NT"` → `"Windows PC"`
+   - Fallback → `"Passkey"`
+
+**Strategy** (prioritises correctness without blocking):
+- On GET, pre-fill the input with the UA-derived hint. User can edit before submitting.
+- On successful POST, if the submitted `name` is blank (user cleared it), use the AAGUID lookup result if available; else fall back to the UA hint; else `"Passkey"`.
+- Truncate to 60 chars.
+
+This keeps the happy path simple (most users hit the UA suggestion and accept it) and gives us a known-good fallback chain.
+
+---
+
+## 5. Implementation Plan
+
+### Task 1 — Remove the homepage passkey panel
+
+**File:** `app/views/welcome/home.rb`
+
+- Delete `render_passkey_card` (lines 157-177).
+- In `render_info_cards`, remove the `render_passkey_card` call. If `render_users_card` is the only survivor and only renders conditionally (`allowed_to?(:index?, User)`), wrap it so the section collapses cleanly for users without that permission:
+  ```ruby
+  def render_info_cards
+    return unless view_context.allowed_to?(:index?, User)
+
+    div(class: "grid gap-6 md:grid-cols-2") do
+      render_users_card
+    end
+  end
+  ```
+  (Alternatively, if this leaves `render_info_cards` one-card-only for everyone, switch to a single-column layout with `max-w-md` to avoid the half-empty grid.)
+
+### Task 2 — Sidebar: mutually exclusive passkey links
+
+**File:** `app/components/sidebar.rb`
+
+Change `render_logged_in_links` (lines 157-179) from an additive pattern to an exclusive one:
+
+```ruby
+def render_logged_in_links
+  render Components::NavItem.new(
+    path: view_context.account_path,
+    label: "My account",
+    icon: Components::Icons::Person.new,
+    delay: "260ms"
+  )
+  if view_context.rodauth.webauthn_setup?
+    render Components::NavItem.new(
+      path: view_context.rodauth.webauthn_remove_path,
+      label: "Manage passkeys",
+      icon: Components::Icons::KeyRemove.new,
+      delay: "300ms"
+    )
+  else
+    render Components::NavItem.new(
+      path: view_context.rodauth.webauthn_setup_path,
+      label: "Add passkey",
+      icon: Components::Icons::Key.new,
+      delay: "300ms"
+    )
+  end
+  render_logout_button
+end
+```
+
+### Task 3 — `/webauthn-remove`: add the "Add another passkey" CTA
+
+**File:** `app/views/rodauth/webauthn_remove.rb`
+
+- At the top of the manage-passkeys card (after the hero/title block, before the form), insert a link styled as a secondary button pointing at `webauthn_setup_path`:
+  ```ruby
+  div(class: "ha-card p-6") do
+    p(class: "ha-overline") { plain "Security" }
+    h2(class: "mt-2 text-lg font-semibold") { plain "Add another passkey" }
+    p(class: "mt-2 text-sm text-[var(--ha-muted)]") do
+      plain "Register another device for faster, safer sign-ins."
+    end
+    div(class: "mt-4") do
+      link_to("Add passkey",
+              view_context.rodauth.webauthn_setup_path,
+              class: "ha-button ha-button-primary")
+    end
+  end
+  ```
+- Include `Phlex::Rails::Helpers::LinkTo` at the top of the class.
+- Keep the existing "Manage passkeys" remove form untouched.
+- Update the radio-button label to include the passkey name (see Task 4).
+
+### Task 4 — Passkey titles
+
+#### 4a. Migration
+
+**File:** `db/migrate/<timestamp>_add_name_to_user_webauthn_keys.rb` (new)
+
+```ruby
+class AddNameToUserWebauthnKeys < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_webauthn_keys, :name, :string, limit: 80
+  end
+end
+```
+
+Nullable on purpose: legacy rows have no name until the user re-registers that key.
+
+#### 4b. Setup form: add the "Passkey name" input
+
+**File:** `app/views/rodauth/webauthn_setup.rb`
+
+- Include `Phlex::Rails::Helpers::Request` (or access `view_context.request.user_agent`).
+- Before the submit button, add a text input:
+  ```ruby
+  suggested_name = Webauthn::NameSuggester.from_user_agent(
+    view_context.request.user_agent
+  )
+  div(class: "space-y-2") do
+    label(class: "text-sm font-medium") { "Passkey name" }
+    form.text_field(
+      "passkey_name",
+      value: suggested_name,
+      maxlength: 60,
+      class: "ha-input",
+      autocomplete: "off",
+      placeholder: "e.g. Mac fingerprint, Pixel phone, Bitwarden"
+    )
+    p(class: "text-xs text-[var(--ha-muted)]") do
+      plain "Give this device a name you’ll recognise later."
+    end
+  end
+  ```
+
+#### 4c. Name suggester
+
+**File:** `app/misc/webauthn/name_suggester.rb` (new)
+
+A small PORO that maps a User-Agent string to a friendly label. One method, `from_user_agent(ua)`, returns a String, capped at 60 chars, defaulting to `"Passkey"`. No dependency on any gem — simple regex matches are enough; the goal is a reasonable hint, not perfect device fingerprinting.
+
+**File:** `app/misc/webauthn/aaguid_lookup.rb` (new)
+
+A static Hash mapping the handful of AAGUIDs we care about (iCloud Keychain, 1Password, Bitwarden, Google Password Manager, Windows Hello, Chrome Profile) to human strings. Build from the public [passkey-authenticator-aaguids registry](https://github.com/passkeydeveloper/passkey-authenticator-aaguids). One method, `lookup(aaguid_string)`, returns a String or nil.
+
+Keeping these as POROs under `app/misc/webauthn/` matches the existing `app/misc/rodauth_main.rb` placement convention.
+
+#### 4d. Persist the name on setup
+
+**File:** `app/misc/rodauth_main.rb`
+
+Add an `after_webauthn_setup` hook inside `configure`:
+
+```ruby
+after_webauthn_setup do
+  submitted = param_or_nil("passkey_name").to_s.strip
+  name = if submitted.present?
+           submitted[0, 60]
+         else
+           aaguid = extract_aaguid(new_webauthn_credential)
+           Webauthn::AaguidLookup.lookup(aaguid) ||
+             Webauthn::NameSuggester.from_user_agent(request.user_agent) ||
+             "Passkey"
+         end
+
+  db[:user_webauthn_keys]
+    .where(user_id: account_id, webauthn_id: new_webauthn_credential.id)
+    .update(name: name)
+end
+```
+
+`extract_aaguid` is a small private helper in the same file that digs `aaguid` out of the webauthn-ruby credential object, returning a UUID string or nil.
+
+#### 4e. Display the name on remove
+
+**File:** `app/views/rodauth/webauthn_remove.rb`
+
+Replace the `account_webauthn_usage.each` block with a direct query that also pulls the name. Example:
+
+```ruby
+keys = ::User
+         .connection
+         .execute(
+           "SELECT webauthn_id, last_use, name FROM user_webauthn_keys " \
+           "WHERE user_id = ? ORDER BY last_use DESC",
+           view_context.rodauth.account_id
+         )
+keys.each do |row|
+  id         = row["webauthn_id"]
+  last_use   = row["last_use"]
+  name_label = row["name"].presence || "Passkey"
+  formatted  = last_use ? Time.parse(last_use.to_s).strftime(...) : "Never"
+  # ... render label with "#{name_label} — Last used: #{formatted}"
+end
+```
+
+Prefer Sequel through `db[...]` (matching the Rodauth DB conn) over raw `ActiveRecord::Base.connection.execute` if it keeps the auth/user-scope boundary clean; both are acceptable — pick the one that matches the existing `db[:user_webauthn_keys]` pattern we introduce in 4d.
+
+### Task 5 — Post-sign-in redirect to /trips
+
+**File:** `app/misc/rodauth_main.rb`
+
+Inside `configure`:
+
+```ruby
+login_redirect "/trips"
+webauthn_setup_redirect "/trips"
+create_account_redirect { "/trips" }   # replaces current "/"
+```
+
+`logout_redirect "/"` and `verify_account_redirect { login_redirect }` stay as they are (after logout, home is the right place).
+
+**Note:** The existing `after_login` hook at lines 205-214 still runs before the redirect — no change there.
+
+### Task 6 — Tests
+
+#### Model / action specs
+
+None required — no changes to models or actions in this phase.
+
+#### Request specs
+
+**File:** `spec/requests/rodauth/webauthn_setup_spec.rb` (new)
+
+- `GET /webauthn-setup` renders the form with a visible `passkey_name` input.
+- `POST /webauthn-setup` with a valid credential + custom `passkey_name` persists the name on the inserted row.
+- `POST /webauthn-setup` with a valid credential + blank `passkey_name` falls back to a UA-derived name.
+- After successful setup, response redirects to `/trips`.
+
+**File:** `spec/requests/rodauth/webauthn_remove_spec.rb` (new or extend)
+
+- `GET /webauthn-remove` shows one entry per passkey with its `name` label.
+- `GET /webauthn-remove` shows an "Add passkey" CTA linking to `/webauthn-setup`.
+
+#### System specs
+
+**File:** `spec/system/passkey_management_spec.rb` (new)
+
+Five flows, all against a seeded logged-in user:
+
+1. Home page no longer shows the "Add a passkey" panel (`expect(page).not_to have_selector(".ha-card", text: "Add a passkey")` on `/`).
+2. Sidebar shows "Add passkey" when the user has **no** passkeys; does **not** show "Manage passkeys".
+3. Sidebar shows "Manage passkeys" when the user has **≥1** passkey; does **not** show "Add passkey".
+4. `/webauthn-remove` shows the "Add another passkey" link.
+5. After sign-in via email-auth (the canonical flow for invited users in this project), the user lands on `/trips`, not `/`.
+
+For flow 3, pre-seed a `user_webauthn_keys` row directly (we can't register a real passkey from a headless browser without stubbing WebAuthn). Flow 5 uses the existing email-auth seam (`spec/system/invitations_spec.rb` pattern).
+
+#### Spec updates
+
+**File:** `spec/system/welcome_spec.rb`
+
+- Drop any assertion that the passkey panel is visible on the logged-in home.
+- Add negative assertion: the logged-in home no longer contains the text "Add a passkey" or "Register a passkey per device".
+
+**File:** `spec/system/invitations_spec.rb`
+
+- Update the Phase 16 auto-login expectation: post-signup, user now lands on `/trips` instead of `/`. Adjust `expect(current_path).to eq("/")` → `expect(current_path).to eq("/trips")`.
+
+---
+
+## 6. Files to Create
+
+| File | Purpose |
+|------|---------|
+| `db/migrate/<ts>_add_name_to_user_webauthn_keys.rb` | `add_column :user_webauthn_keys, :name, :string, limit: 80` |
+| `app/misc/webauthn/name_suggester.rb` | UA → friendly passkey label |
+| `app/misc/webauthn/aaguid_lookup.rb` | AAGUID → authenticator name |
+| `spec/requests/rodauth/webauthn_setup_spec.rb` | Name persistence + redirect on setup |
+| `spec/requests/rodauth/webauthn_remove_spec.rb` | Name display + Add-passkey CTA on remove |
+| `spec/system/passkey_management_spec.rb` | Home panel gone, sidebar mutex, /trips redirect |
+
+## 7. Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/views/welcome/home.rb` | Delete `render_passkey_card`; update `render_info_cards` (Task 1) |
+| `app/components/sidebar.rb` | Mutually exclusive Add / Manage passkey links (Task 2) |
+| `app/views/rodauth/webauthn_remove.rb` | Add "Add another passkey" CTA; display passkey name next to last-used (Tasks 3 + 4e) |
+| `app/views/rodauth/webauthn_setup.rb` | Add "Passkey name" input with UA-derived pre-fill (Task 4b) |
+| `app/misc/rodauth_main.rb` | `after_webauthn_setup` hook; `login_redirect`, `webauthn_setup_redirect`, `create_account_redirect` to `/trips` (Tasks 4d + 5) |
+| `spec/system/welcome_spec.rb` | Drop panel assertion (Task 6) |
+| `spec/system/invitations_spec.rb` | Update post-signup redirect assertion to `/trips` (Task 6) |
+
+---
+
+## 8. Key Design Decisions
+
+1. **Keep `verify_account` alone.** Phase 16 already handled the verify-account fast-path for invited signups; this phase piggybacks on that without changing it. The only Rodauth flag we touch is redirects + one new hook.
+
+2. **Name column, not a separate table.** A `passkey_credentials` side table would be more normalised but buys nothing today (passkeys already have a 1:1 relationship with `user_webauthn_keys` rows). One nullable column is the minimum viable change, reversible via a rollback migration.
+
+3. **Auto-suggest > require.** The user-facing field is pre-filled and editable. We never block setup because the name is empty — we fall back (submitted → AAGUID → UA → `"Passkey"`). This matches the rest of the onboarding philosophy from Phase 16 (don't introduce friction).
+
+4. **Sidebar mutual exclusion, not "show both + grey one out".** Either the user has no passkey (one action: add) or they have at least one (one action: manage, which itself leads to add). Two active calls-to-action at once is what surfaced as confusing in live use.
+
+5. **`/trips` as the post-sign-in home.** For a trip-journaling app, the destination is trips. The current `/` has become a dashboard-style summary; it's useful, but it's *after* the user has picked a trip, not the landing point. Moving `login_redirect` doesn't remove `/` — it's still reachable from the sidebar "Overview" link.
+
+6. **No edit-name flow for existing passkeys.** Out of scope. Legacy rows stay `name IS NULL` and show as `"Passkey"`. If this bites in practice, a follow-up phase can add an inline-edit on `/webauthn-remove` — but committing to it now risks scope-creep when the Round-2 cleanup is primarily about removing panels and redirecting.
+
+7. **AAGUID lookup as a static Hash, not a gem.** The [passkey-authenticator-aaguids](https://github.com/passkeydeveloper/passkey-authenticator-aaguids) list covers ~40 entries; the ones our user base will hit are a handful (iCloud Keychain, 1Password, Bitwarden, Google PM, Windows Hello, Chrome Profile). A static Hash keeps the dependency surface zero; we can expand or switch to a gem later if the list grows unmanageable.
+
+8. **`after_webauthn_setup` + row UPDATE rather than overriding `add_webauthn_credential`.** The override path is brittle (Rodauth internals can change the column set or the insert path between versions). The hook is stable and does exactly what we need: "after Rodauth inserted the row, write the extra column we own."
+
+---
+
+## 9. Risks
+
+1. **User-Agent auto-suggestions can be wrong or awkward** (e.g. Safari on iPad says `"iPad"` but WebKit on iOS also claims `iPad` from desktop-mode). **Mitigation:** the field is editable and clearly labelled. The cost of a wrong suggestion is one keystroke.
+
+2. **AAGUID may be absent** on older authenticators or when attestation is `"none"` (the default in Rodauth's webauthn-ruby config). **Mitigation:** the UA fallback catches this; worst case we land at `"Passkey"` and the user edits.
+
+3. **The remove screen's direct SQL query** ([Task 4e](#4e-display-the-name-on-remove)) sidesteps `account_webauthn_usage`. If Rodauth changes the column set or table name between versions, this query drifts. **Mitigation:** the project already has direct SQL patterns (e.g. the Rodauth Sequel DB handle in `rodauth_main.rb`), and the table/column names here are stable Rodauth-configured values (`webauthn_keys_table`). An alternative is to keep calling `account_webauthn_usage` for the `id → last_use` map and do a single extra query for `id → name`, merging in Ruby — cleaner but more code. The plan prefers the single query; the reviewer should flag if they prefer the merge approach.
+
+4. **Changing `login_redirect` to `/trips` globally** affects every sign-in path, not just invited signups. An admin signing in also lands on `/trips`. **Mitigation:** this is the ask ("Once connected"), and the sidebar "Overview" link is always one click away. If this turns out to be wrong for the admin role, a follow-up can branch on `current_user.role?(:superadmin)` inside `login_redirect { ... }`.
+
+5. **Tests that stub WebAuthn credential creation** are heavy. **Mitigation:** for unit/request-level assertions (Task 6), we can insert the row directly into `user_webauthn_keys` and assert rendering; we don't need to drive a real WebAuthn attestation ceremony. The existing `spec/system/webauthn_autofill_spec.rb` shows the pattern.
+
+6. **Tailwind JIT** — the new `ha-input` usage on the setup form and all existing `ha-button` classes are already compiled. No new custom class is introduced. A Docker rebuild is **not** required for CSS reasons, but `bin/cli app rebuild` is mandatory anyway for the migration to run and for `/product-review` to pass.
+
+---
+
+## 10. Verification
+
+### Pre-commit (local)
+
+```bash
+mise x -- bundle exec rake project:fix-lint
+mise x -- bundle exec rake project:lint
+mise x -- bundle exec rake project:tests
+mise x -- bundle exec rake project:system-tests
+```
+
+### Runtime Verification (per `/product-review` skill)
+
+```bash
+bin/cli app rebuild   # picks up the migration
+bin/cli app restart
+bin/cli mail start
+```
+
+Then with `agent-browser` against `https://catalyst.workeverywhere.docker/`:
+
+**Logged-in home (`/`)**
+- [ ] No "Add a passkey" card anywhere on the page
+- [ ] Users card still renders for superadmin
+- [ ] Layout doesn't look half-empty for non-admin users
+
+**Sidebar (no passkeys registered)**
+- [ ] "Add passkey" link is visible
+- [ ] "Manage passkeys" link is **not** visible
+
+**Sidebar (≥1 passkey registered)**
+- [ ] "Manage passkeys" link is visible
+- [ ] "Add passkey" link is **not** visible
+
+**Passkey registration (`/webauthn-setup`)**
+- [ ] A "Passkey name" text input is present, pre-filled with a sensible UA-based suggestion (e.g. `"Mac (Chrome)"` on a Mac Chrome session)
+- [ ] Submitting the form with a custom name persists that exact name
+- [ ] Submitting the form with a blank name persists the UA fallback (or AAGUID if available)
+- [ ] After success, the browser lands on `/trips`
+
+**Manage passkeys (`/webauthn-remove`)**
+- [ ] Each listed passkey shows `"<name> — Last used: <ts>"` rather than only a timestamp
+- [ ] Legacy rows (if any) show `"Passkey — Last used: <ts>"`
+- [ ] An "Add another passkey" button/link is visible and routes to `/webauthn-setup`
+- [ ] Removing a passkey still works end-to-end
+
+**Post-sign-in redirect**
+- [ ] Complete an email-auth sign-in → lands on `/trips`
+- [ ] Complete an invitation signup (invited flow from Phase 16) → lands on `/trips`
+- [ ] Sign out → lands on `/`
+
+### Security Gates (per `/security-review` skill)
+
+```bash
+mise x -- bundle exec brakeman --no-pager
+mise x -- bundle exec bundle-audit check --update
+```
+
+Pay particular attention to:
+- The raw SQL in `webauthn_remove.rb` — make sure `account_id` is passed as a bound parameter, not interpolated.
+- The `after_webauthn_setup` hook — `param_or_nil("passkey_name")` is user input; it's trimmed and length-capped at 60 before insertion.
+- No new XSS paths: the name is rendered through Phlex's `plain` helper, which escapes by default. Flag any `unsafe_raw` / `raw` on this surface.
+
+### GitHub Workflow (per `/execution-plan` skill)
+
+1. Create an issue on [Trip Issues](https://github.com/joel/trip/issues) titled **"Phase 17: Onboarding Improvements — Round 2 (Passkey UX)"** with a link to this plan.
+2. Add labels: `feature`, `cleanup`, `ux`.
+3. Move through Backlog → Ready → In Progress on the [Trip Kanban Board](https://github.com/users/joel/projects/2/views/1).
+4. Branch: `feature/phase17-passkey-ux`.
+5. One PR covering all five tasks (they share the passkey surface and are tightly coupled).
+6. Move to In Review on PR open; respond to every review comment; resolve every conversation.
+
+---
+
+## 11. Task Order (one PR, atomic commits per task)
+
+1. **Commit 1** — Remove passkey panel from logged-in home (Task 1 + `welcome_spec` update)
+2. **Commit 2** — Sidebar: mutually exclusive Add/Manage passkey (Task 2 + system spec flows 2 + 3)
+3. **Commit 3** — Add migration + name column scaffolding (Task 4a only — just the DDL, keeps the commit small and rollback-easy)
+4. **Commit 4** — Setup form collects passkey name; after-setup hook persists it (Tasks 4b, 4c, 4d + setup request spec)
+5. **Commit 5** — Remove screen displays names + adds Add-passkey CTA (Tasks 3 + 4e + remove request spec)
+6. **Commit 6** — `login_redirect` / `webauthn_setup_redirect` / `create_account_redirect` → `/trips` (Task 5 + invitations + passkey_management system specs)
+
+Each commit is independently reversible. All six touch runtime code; **no `[skip ci]`** on any of them. No `SKIP=<Hook>` needed unless the migration+schema check flags a false positive (document if so).
+
+---
+
+## 12. Quality Checklist
+
+- [x] All five user-reported issues mapped to a concrete task
+- [x] All new code paths have a matching spec
+- [x] Validation gates are executable by project skills
+- [x] References existing Rodauth + Phlex + Tailwind patterns
+- [x] Clear commit ordering, each commit independently valid
+- [x] Risks identified and mitigated
+- [x] No changes to public API, MCP surface, or schema shape of any existing table other than one additive nullable column
+- [x] Backwards-compatible: legacy passkey rows render cleanly without the new column
+- [x] Mandatory `/product-review` coverage plan is explicit (pages + exact expectations)

--- a/spec/misc/webauthn/aaguid_lookup_spec.rb
+++ b/spec/misc/webauthn/aaguid_lookup_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webauthn::AaguidLookup do
+  describe ".lookup" do
+    it "returns the friendly name for a known AAGUID" do
+      expect(described_class.lookup("adce0002-35bc-c60a-648b-0b25f1f05503"))
+        .to eq("Chrome on Mac")
+    end
+
+    it "is case-insensitive" do
+      expect(described_class.lookup("ADCE0002-35BC-C60A-648B-0B25F1F05503"))
+        .to eq("Chrome on Mac")
+    end
+
+    it "returns nil for unknown AAGUIDs" do
+      expect(described_class.lookup("00000000-0000-0000-0000-000000000000"))
+        .to be_nil
+    end
+
+    it "returns nil for blank input" do
+      expect(described_class.lookup(nil)).to be_nil
+      expect(described_class.lookup("")).to be_nil
+    end
+  end
+end

--- a/spec/misc/webauthn/name_suggester_spec.rb
+++ b/spec/misc/webauthn/name_suggester_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webauthn::NameSuggester do
+  describe ".from_user_agent" do
+    it "returns 'Passkey' for a blank or nil user agent" do
+      expect(described_class.from_user_agent(nil)).to eq("Passkey")
+      expect(described_class.from_user_agent("")).to eq("Passkey")
+    end
+
+    it "detects iPhone" do
+      ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+      expect(described_class.from_user_agent(ua)).to eq("iPhone")
+    end
+
+    it "detects iPad" do
+      ua = "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+      expect(described_class.from_user_agent(ua)).to eq("iPad")
+    end
+
+    it "detects Mac with Chrome" do
+      ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0"
+      expect(described_class.from_user_agent(ua)).to eq("Mac (Chrome)")
+    end
+
+    it "detects Mac with Safari (no Chrome token)" do
+      ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15"
+      expect(described_class.from_user_agent(ua)).to eq("Mac (Safari)")
+    end
+
+    it "detects Mac with Edge" do
+      ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0 Edg/120.0"
+      expect(described_class.from_user_agent(ua)).to eq("Mac (Edge)")
+    end
+
+    it "detects Pixel phone" do
+      ua = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36"
+      expect(described_class.from_user_agent(ua)).to eq("Pixel phone")
+    end
+
+    it "detects generic Android" do
+      ua = "Mozilla/5.0 (Linux; Android 14; SM-G998B) AppleWebKit/537.36"
+      expect(described_class.from_user_agent(ua)).to eq("Android phone")
+    end
+
+    it "detects Windows PC" do
+      ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+      expect(described_class.from_user_agent(ua)).to eq("Windows PC")
+    end
+
+    it "truncates results longer than 60 chars" do
+      stub_const("#{described_class}::DEFAULT", "x" * 100)
+      expect(described_class.from_user_agent("").length).to eq(60)
+    end
+  end
+end

--- a/spec/requests/rodauth/webauthn_remove_spec.rb
+++ b/spec/requests/rodauth/webauthn_remove_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rodauth webauthn remove page" do
+  let(:user) { create(:user, :superadmin) }
+
+  before do
+    seed_passkey(user, webauthn_id: "key-1", name: "Mac fingerprint")
+    seed_passkey(user, webauthn_id: "key-2", name: nil)
+    get "/test/login", params: { user_id: user.id }
+  end
+
+  def seed_passkey(user, webauthn_id:, name:)
+    ActiveRecord::Base.connection.exec_insert(
+      "INSERT INTO user_webauthn_keys " \
+      "(user_id, webauthn_id, public_key, sign_count, last_use, name) " \
+      "VALUES (?, ?, ?, ?, ?, ?)",
+      "seed_passkey",
+      [user.id, webauthn_id, "pub-#{webauthn_id}", 0, Time.current.iso8601, name]
+    )
+  end
+
+  it "shows the named passkey and falls back to 'Passkey' for unnamed rows" do
+    get "/webauthn-remove"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Mac fingerprint")
+    expect(response.body).to include("Passkey")
+    expect(response.body).to match(/Last used:/)
+  end
+
+  it "renders an Add passkey link pointing at /webauthn-setup" do
+    get "/webauthn-remove"
+
+    expect(response.body).to include("Add another passkey")
+    expect(response.body).to match(%r{href="/webauthn-setup"[^>]*>\s*Add passkey}m)
+  end
+end

--- a/spec/requests/rodauth/webauthn_setup_spec.rb
+++ b/spec/requests/rodauth/webauthn_setup_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Rodauth webauthn setup page" do
+  let(:user) { create(:user, :superadmin) }
+
+  before { get "/test/login", params: { user_id: user.id } }
+
+  it "renders the Passkey name input with a UA-derived suggestion" do
+    get "/webauthn-setup",
+        headers: { "User-Agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0" }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('name="passkey_name"')
+    expect(response.body).to include('value="Mac (Chrome)"')
+    expect(response.body).to include("Passkey name")
+  end
+
+  it "falls back to 'Passkey' when the user agent is empty" do
+    get "/webauthn-setup", headers: { "User-Agent" => "" }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('value="Passkey"')
+  end
+end

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Invitations" do
       visit "/create-account?invitation_token=#{invitation.token}"
       click_on "Create Account"
 
-      expect(page).to have_current_path("/")
+      expect(page).to have_current_path("/trips")
 
       user = User.find_by(email: "new-invitee@example.com")
       expect(user).not_to be_nil

--- a/spec/system/passkey_management_spec.rb
+++ b/spec/system/passkey_management_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Passkey management surface" do
+  let(:user) { create(:user, :superadmin) }
+
+  before { login_as(user: user) }
+
+  def seed_passkey(user, webauthn_id: SecureRandom.uuid, name: nil)
+    conn = ActiveRecord::Base.connection
+    columns = %w[user_id webauthn_id public_key sign_count last_use]
+    values = [user.id, webauthn_id, "stub-public-key", 0, Time.current.iso8601]
+    if conn.columns("user_webauthn_keys").any? { |c| c.name == "name" }
+      columns << "name"
+      values << name
+    end
+    placeholders = columns.map { "?" }.join(", ")
+    sql = "INSERT INTO user_webauthn_keys (#{columns.join(", ")}) VALUES (#{placeholders})"
+    conn.exec_insert(sql, "seed_passkey", values)
+  end
+
+  context "when the user has no passkeys registered" do
+    it "shows the Add passkey link in the sidebar and hides Manage passkeys" do
+      visit root_path
+      within("nav[aria-label='Main navigation']") do
+        expect(page).to have_link("Add passkey")
+        expect(page).to have_no_link("Manage passkeys")
+      end
+    end
+  end
+
+  context "when the user has at least one passkey registered" do
+    before { seed_passkey(user) }
+
+    it "shows the Manage passkeys link and hides Add passkey in the sidebar" do
+      visit root_path
+      within("nav[aria-label='Main navigation']") do
+        expect(page).to have_link("Manage passkeys")
+        expect(page).to have_no_link("Add passkey")
+      end
+    end
+  end
+end

--- a/spec/system/welcome_spec.rb
+++ b/spec/system/welcome_spec.rb
@@ -21,5 +21,12 @@ RSpec.describe "Welcome" do
       expect(page).to have_content(/Welcome,/)
       expect(page).to have_content("New Trip")
     end
+
+    it "does not render the Add a passkey security panel" do
+      visit root_path
+      expect(page).to have_content(/Welcome,/) # anchor to ensure page loaded
+      expect(page).to have_no_content("Add a passkey")
+      expect(page).to have_no_content("Register a passkey per device")
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Removes the "Add a passkey" panel** from the logged-in home. Info cards are now a single admin-only "Stay connected" card.
- **Sidebar is mutually exclusive**: shows `Add passkey` when the user has none, or `Manage passkeys` when they do — never both.
- **Adds an "Add another passkey" CTA** at the top of `/webauthn-remove` so the manage screen is the canonical place to register another device now that the sidebar hides `Add passkey` for users with one on file.
- **Passkey titles.** New nullable `user_webauthn_keys.name` column; `/webauthn-setup` collects a user-editable name pre-filled with a UA-derived suggestion (`Mac (Chrome)`, `Pixel phone`, `Linux device`, …). Persistence goes through a `webauthn_key_insert_hash` override with a resolution chain: submitted → AAGUID lookup → UA heuristic → `Passkey`. Legacy rows render as `Passkey` until re-registration.
- **`login_redirect`, `create_account_redirect`, and `webauthn_setup_redirect` all resolve to `/trips`** — where an authenticated user actually wants to be. `/` stays reachable from the sidebar Overview link.

Plan: `prompts/Phase 17 Onboarding Improvements Round 2.md`
Audit trail: `prompts/Phase 17 - Steps.md`

## Test plan

- [x] `mise x -- bundle exec rake project:lint` passes
- [x] `mise x -- bundle exec rake project:tests` — 606 examples, 0 failures
- [x] `mise x -- bundle exec rake project:system-tests` — 68 examples, 0 failures
- [x] `brakeman` — 0 security warnings
- [x] `bundle-audit check --update` — 0 vulnerabilities
- [x] All overcommit hooks pass
- [x] Live verification at https://catalyst.workeverywhere.docker:
  - Logged-out home shows only "Request an invitation" card.
  - Email-auth sign-in lands on `/trips` (login_redirect applied).
  - Logged-in home no longer shows an Add-a-passkey card.
  - Sidebar shows `Manage passkeys` only (user has a passkey), `Add passkey` hidden.
  - `/webauthn-remove` shows the "Add another passkey" card at top; legacy passkey rows render as `Passkey — Last used: <ts>`.
  - `/webauthn-setup` pre-fills "Passkey name" with a UA-derived suggestion.
  - `/account`, `/users`, `/trips` all render cleanly.

Closes #112