### PR TITLE
Phase 19 Phase 1 - Agent Identity (Registered Agents)

### DIFF
--- a/.claude/skills/trip-journal-mcp/SKILL.md
+++ b/.claude/skills/trip-journal-mcp/SKILL.md
@@ -28,16 +28,22 @@ You are connecting to the Trip Journal MCP server as **Jack**, an AI travel assi
     "trip-journal": {
       "url": "https://catalyst.workeverywhere.docker/mcp",
       "headers": {
-        "Authorization": "Bearer <MCP_API_KEY>"
+        "Authorization": "Bearer <MCP_API_KEY>",
+        "X-Agent-Identifier": "jack"
       }
     }
   }
 }
 ```
 
-### API Key Scope
+The `X-Agent-Identifier` header is **required** — it must match the slug of a registered `Agent` record. Missing or unknown slug returns JSON-RPC error `-32001` with a readable message. Swap the slug when configuring a different agent (e.g. `"maree"` for Marée).
 
-The `MCP_API_KEY` grants **unrestricted read/write access to all domain data**. All actions are attributed to the Jack system actor (`jack@system.local`). This is by design -- Jack operates on behalf of the user across all trips.
+### Authentication and Agent Identity
+
+Two layers:
+
+- `MCP_API_KEY` (Bearer): shared channel secret. Grants access to the endpoint. Missing/wrong → HTTP 401.
+- `X-Agent-Identifier`: slug of a registered Agent. Resolves to the agent's `@system.local` User, used as author/actor for writes. All actions attributed to that user. Missing/unknown → JSON-RPC `-32001`.
 
 ## Tools Reference
 
@@ -45,7 +51,7 @@ The `MCP_API_KEY` grants **unrestricted read/write access to all domain data**. 
 
 | Tool | Description | Required | Optional |
 |------|-------------|----------|----------|
-| `create_journal_entry` | Create a journal entry | `name`, `entry_date` | `trip_id`, `body`, `location_name`, `description`, `actor_type`, `actor_id`, `telegram_message_id` |
+| `create_journal_entry` | Create a journal entry | `name`, `entry_date` | `trip_id`, `body`, `location_name`, `description`, `telegram_message_id` |
 | `update_journal_entry` | Update an existing entry | `journal_entry_id` + at least one field | `name`, `body`, `entry_date`, `location_name`, `description` |
 | `list_journal_entries` | List entries with pagination | (none) | `trip_id`, `limit` (1-100, default 10), `offset` (>= 0) |
 
@@ -98,7 +104,6 @@ Use `get_trip_status` without a `trip_id` to discover the active trip, or use `l
 
 | Field | Constraint |
 |-------|-----------|
-| `actor_type` | Enum: `Jack`, `System` |
 | `emoji` | Enum: `thumbsup`, `heart`, `tada`, `eyes`, `fire`, `rocket` |
 | `new_state` | Enum: `planning`, `started`, `finished`, `cancelled`, `archived` |
 | `limit` | Clamped to 1-100 |
@@ -144,14 +149,16 @@ Tools enforce state constraints. Calling a tool on an incompatible trip state re
 | Level | Behavior |
 |-------|----------|
 | **Transport** | 415 for wrong Content-Type, JSON-RPC `-32700` for malformed JSON |
-| **Auth** | 401 for missing/invalid Bearer token |
+| **Auth (Bearer)** | 401 for missing/invalid Bearer token |
+| **Auth (Agent)** | JSON-RPC `-32001` (HTTP 200) for missing/unknown `X-Agent-Identifier` |
 | **Tool** | `isError: true` in MCP response with descriptive message |
 
 Error messages are actionable:
 - `"Trip not found: <uuid>"` -- invalid trip_id
 - `"Trip '<name>' is not writable (state: finished)"` -- state guard violation
 - `"No updatable parameters provided"` -- empty update rejected
-- `"Invalid actor_type \"hacker\". Must be one of: Jack, System"` -- enum violation
+- `"Missing X-Agent-Identifier header. Configure your MCP client with the slug of your registered agent (e.g. 'jack')."` -- no header
+- `"Agent 'ghost' is not registered. Ask the admin to create an Agent record with this slug."` -- unknown slug
 
 ## Common Workflows
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,14 @@ When a PR receives code review comments:
 
 ---
 
-## MCP API Key Scope
+## MCP Authentication and Agent Identity
 
-The `MCP_API_KEY` environment variable controls access to the MCP endpoint (`POST /mcp`). A valid key grants **unrestricted read/write access to all domain data** through the 12 registered MCP tools (journal entries, images, comments, reactions, trips, checklists). All MCP actions are attributed to the **Jack** system actor (`jack@system.local`). This is by design — Jack is the AI travel assistant and needs full access to operate on behalf of the user.
+MCP requests carry two pieces of identity:
+
+1. **`MCP_API_KEY`** — shared Bearer token for the endpoint (channel auth). A valid key grants **unrestricted read/write access to all domain data** through the 12 registered MCP tools (journal entries, images, comments, reactions, trips, checklists). Missing/wrong key → HTTP 401.
+2. **`X-Agent-Identifier` header** — slug of a registered `Agent` record (e.g. `jack`, `maree`). Resolves to the agent's system User, which is used as the author/actor for all writes (journal entries, comments, reactions). Missing or unknown slug → JSON-RPC error `-32001` with a readable message (HTTP 200 so the client sees it in-band). Register agents via Rails console: `Agent.create!(slug: "...", name: "...", user: <system_user>)`.
+
+Each agent has its own `@system.local` User. Subscription filters (`JournalEntries::Create#subscribe_trip_members`) exclude system actors from auto-subscription, so agents don't email themselves.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,12 @@ MCP Client  --POST /mcp-->  McpController  -->  TripJournalServer  -->  12 Tools
 
 ### Configuration
 
-Set `MCP_API_KEY` in your environment. The key grants full read/write access to all domain data via the Jack system actor (`jack@system.local`).
+Two pieces of configuration are required:
+
+1. `MCP_API_KEY` — the shared Bearer token for the endpoint (channel auth).
+2. `X-Agent-Identifier` header — the slug of a registered `Agent` record (e.g. `jack`, `maree`). Attribution flows from the resolved agent's user; each agent has its own `@system.local` User.
+
+Missing or unknown `X-Agent-Identifier` returns JSON-RPC error `-32001` with a readable message. Register new agents via Rails console: `Agent.create!(slug: "...", name: "...", user: <system_user>)`.
 
 ```json
 {
@@ -242,7 +247,8 @@ Set `MCP_API_KEY` in your environment. The key grants full read/write access to 
     "trip-journal": {
       "url": "https://catalyst.workeverywhere.docker/mcp",
       "headers": {
-        "Authorization": "Bearer your-mcp-api-key"
+        "Authorization": "Bearer your-mcp-api-key",
+        "X-Agent-Identifier": "jack"
       }
     }
   }

--- a/app/actions/journal_entries/create.rb
+++ b/app/actions/journal_entries/create.rb
@@ -24,16 +24,12 @@ module JournalEntries
       user_ids = entry.trip.members
                       .where.not("email LIKE ?", "%@system.local")
                       .pluck(:id)
-      user_ids |= [entry.author_id] unless system_actor?(entry.author)
+      user_ids |= [entry.author_id] unless entry.author&.system_actor?
       user_ids.each do |uid|
         entry.journal_entry_subscriptions
              .find_or_create_by!(user_id: uid)
       end
       Success()
-    end
-
-    def system_actor?(user)
-      user&.email&.end_with?("@system.local")
     end
 
     def emit_event(entry)

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -7,15 +7,18 @@ class McpController < ActionController::API
   def handle
     body = request.body.read
     JSON.parse(body) # Validate JSON before passing to MCP
+
+    return render_agent_error(:missing) if agent_slug.blank?
+
+    agent = Agent.by_slug(agent_slug)
+    return render_agent_error(:unknown, agent_slug) if agent.nil?
+
     server = TripJournalServer.build(
-      server_context: { request_id: request.uuid }
+      server_context: { request_id: request.uuid, agent: agent }
     )
     render json: server.handle_json(body)
   rescue JSON::ParserError
-    render json: {
-      jsonrpc: "2.0", id: nil,
-      error: { code: -32_700, message: "Parse error" }
-    }, status: :ok
+    render json: parse_error_payload, status: :ok
   end
 
   private
@@ -35,5 +38,31 @@ class McpController < ActionController::API
     return if content_type.start_with?("application/json")
 
     head(:unsupported_media_type)
+  end
+
+  def agent_slug
+    @agent_slug ||= request.headers["X-Agent-Identifier"].to_s.strip
+  end
+
+  def render_agent_error(kind, slug = nil)
+    message =
+      case kind
+      when :missing
+        "Missing X-Agent-Identifier header. Configure your MCP " \
+        "client with the slug of your registered agent " \
+        "(e.g. 'jack')."
+      when :unknown
+        "Agent '#{slug}' is not registered. Ask the admin to " \
+        "create an Agent record with this slug."
+      end
+    render json: {
+      jsonrpc: "2.0", id: nil,
+      error: { code: -32_001, message: message }
+    }, status: :ok
+  end
+
+  def parse_error_payload
+    { jsonrpc: "2.0", id: nil,
+      error: { code: -32_700, message: "Parse error" } }
   end
 end

--- a/app/mcp/README.md
+++ b/app/mcp/README.md
@@ -9,20 +9,22 @@ The Model Context Protocol (MCP) server exposes trip journaling capabilities to 
 ```
   MCP Client (Claude, Cursor, etc.)
        |
-       | POST /mcp  (Bearer token, application/json)
+       | POST /mcp  (Bearer token, application/json,
+       |             X-Agent-Identifier: <slug>)
        v
   McpController
-       | authenticate_api_key!
-       | validate_content_type! (415 if not JSON)
-       | rescue JSON::ParserError (-32700)
+       | authenticate_api_key!              --> 401 if Bearer invalid
+       | validate_content_type!             --> 415 if not JSON
+       | rescue JSON::ParserError           --> -32700
+       | resolve X-Agent-Identifier         --> -32001 if missing/unknown
        v
   TripJournalServer (MCP::Server)
        | routes JSON-RPC: initialize, tools/list, tools/call
+       | instructions_for(agent) templates the persona
        v
   Tools::BaseTool
-       | resolve_trip, resolve_jack_user
+       | resolve_trip, resolve_agent_user(server_context)
        | require_writable!, require_commentable!
-       | validate_actor_type!
        | success_response / error_response
        v
   12 MCP Tools  -->  Actions (Dry::Monads)  -->  ActiveRecord
@@ -33,15 +35,27 @@ The Model Context Protocol (MCP) server exposes trip journaling capabilities to 
 | | |
 |---|---|
 | **URL** | `POST /mcp` |
-| **Auth** | `Authorization: Bearer <MCP_API_KEY>` |
+| **Auth** | `Authorization: Bearer <MCP_API_KEY>` + `X-Agent-Identifier: <slug>` |
 | **Content-Type** | `application/json` (required, returns 415 otherwise) |
 | **Protocol** | JSON-RPC 2.0 (MCP specification) |
 
-## API Key Scope
+## Authentication and Agent Identity
 
-The `MCP_API_KEY` grants **unrestricted read/write access to all domain data** through the 12 registered tools. All actions are attributed to the **Jack** system actor (`jack@system.local`). This is by design -- Jack is the AI travel assistant and needs full access to operate.
+Requests carry two identity layers:
 
-Set the key in `.env.development`:
+- **`MCP_API_KEY`** (HTTP `Authorization: Bearer …`) — shared channel secret. Grants access to the endpoint. Missing/wrong → HTTP 401.
+- **`X-Agent-Identifier`** — slug of a registered `Agent` record. Resolves to the agent's `@system.local` User, used as author/actor for all writes. Missing/unknown → JSON-RPC `-32001` (HTTP 200 so the client sees the message).
+
+Each agent has a `Agent(slug, name, user)` record. Register via Rails console:
+
+```ruby
+user = User.find_or_create_by!(email: "maree@system.local") { |u|
+  u.name = "Marée"; u.status = 2
+}
+Agent.create!(slug: "maree", name: "Marée", user: user)
+```
+
+Set the endpoint secret in `.env.development`:
 
 ```
 MCP_API_KEY=your-secret-key
@@ -96,7 +110,6 @@ When `trip_id` is omitted, tools automatically resolve to the single trip in `st
 
 | Constraint | Details |
 |-----------|---------|
-| **actor_type** | Must be `Jack` or `System` (enum) |
 | **emoji** | Must be one of: `thumbsup`, `heart`, `tada`, `eyes`, `fire`, `rocket` (enum) |
 | **new_state** | Must be one of: `planning`, `started`, `finished`, `cancelled`, `archived` (enum) |
 | **limit** | Clamped to 1-100 |

--- a/app/mcp/tools/add_reaction.rb
+++ b/app/mcp/tools/add_reaction.rb
@@ -19,11 +19,12 @@ module Tools
       required: %w[journal_entry_id emoji]
     )
 
-    def self.call(journal_entry_id:, emoji:, _server_context: {})
+    def self.call(journal_entry_id:, emoji:, server_context: {})
       entry = JournalEntry.find(journal_entry_id)
       require_commentable!(entry.trip)
+      user = resolve_agent_user(server_context)
       result = Reactions::Toggle.new.call(
-        reactable: entry, user: resolve_jack_user, emoji: emoji
+        reactable: entry, user: user, emoji: emoji
       )
       format_result(result, emoji, journal_entry_id)
     rescue ToolError => e

--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -4,8 +4,6 @@ module Tools
   class BaseTool < MCP::Tool
     class ToolError < StandardError; end
 
-    VALID_ACTOR_TYPES = %w[Jack System].freeze
-
     # -- Shared response helpers --
 
     private_class_method def self.success_response(data)
@@ -48,11 +46,13 @@ module Tools
       raise ToolError, "Trip not found: #{trip_id}"
     end
 
-    private_class_method def self.resolve_jack_user
-      User.find_or_create_by!(email: "jack@system.local") do |u|
-        u.name = "Jack"
-        u.status = 2
-      end
+    # -- Agent resolution --
+
+    private_class_method def self.resolve_agent_user(server_context)
+      agent = server_context&.dig(:agent)
+      raise ToolError, "No agent in server context" if agent.nil?
+
+      agent.user
     end
 
     # -- Guards --
@@ -71,14 +71,6 @@ module Tools
       raise ToolError,
             "Trip '#{trip.name}' is not commentable " \
             "(state: #{trip.state})"
-    end
-
-    private_class_method def self.validate_actor_type!(actor_type)
-      return if VALID_ACTOR_TYPES.include?(actor_type)
-
-      raise ToolError,
-            "Invalid actor_type \"#{actor_type}\". " \
-            "Must be one of: #{VALID_ACTOR_TYPES.join(", ")}"
     end
   end
 end

--- a/app/mcp/tools/create_comment.rb
+++ b/app/mcp/tools/create_comment.rb
@@ -20,13 +20,14 @@ module Tools
     )
 
     def self.call(journal_entry_id:, body:,
-                  telegram_message_id: nil, _server_context: {})
+                  telegram_message_id: nil, server_context: {})
       entry = JournalEntry.find(journal_entry_id)
       require_commentable!(entry.trip)
+      user = resolve_agent_user(server_context)
       idempotent = find_existing(entry, telegram_message_id)
       return comment_response(idempotent) if idempotent
 
-      create_comment(entry, body, telegram_message_id)
+      create_comment(entry, body, telegram_message_id, user)
     rescue ToolError => e
       error_response(e.message)
     rescue ActiveRecord::RecordNotUnique
@@ -46,11 +47,10 @@ module Tools
       entry.comments.find_by(telegram_message_id: msg_id)
     end
 
-    private_class_method def self.create_comment(entry, body, msg_id)
+    private_class_method def self.create_comment(entry, body, msg_id, user)
       params = { body: body, telegram_message_id: msg_id }.compact
       result = Comments::Create.new.call(
-        params: params, journal_entry: entry,
-        user: resolve_jack_user
+        params: params, journal_entry: entry, user: user
       )
       case result
       in Dry::Monads::Success(comment)

--- a/app/mcp/tools/create_journal_entry.rb
+++ b/app/mcp/tools/create_journal_entry.rb
@@ -27,16 +27,6 @@ module Tools
         description: {
           type: "string", description: "Short summary"
         },
-        actor_type: {
-          type: "string",
-          description: "Actor type for attribution",
-          default: "Jack",
-          enum: VALID_ACTOR_TYPES
-        },
-        actor_id: {
-          type: "string",
-          description: "Actor identifier", default: "jack"
-        },
         telegram_message_id: {
           type: "string",
           description: "Telegram message ID for idempotency"
@@ -48,16 +38,14 @@ module Tools
     # rubocop:disable Metrics/ParameterLists
     def self.call(name:, entry_date:, trip_id: nil, body: nil,
                   location_name: nil, description: nil,
-                  actor_type: "Jack", actor_id: "jack",
-                  telegram_message_id: nil, _server_context: {})
-      validate_actor_type!(actor_type)
+                  telegram_message_id: nil, server_context: {})
       trip = resolve_trip(trip_id)
       require_writable!(trip)
+      user = resolve_agent_user(server_context)
       idempotent_check(trip, telegram_message_id) || create_entry(
         trip: trip, name: name, entry_date: entry_date, body: body,
         location_name: location_name, description: description,
-        actor_type: actor_type, actor_id: actor_id,
-        telegram_message_id: telegram_message_id
+        telegram_message_id: telegram_message_id, user: user
       )
     rescue ToolError => e
       error_response(e.message)
@@ -73,9 +61,9 @@ module Tools
       entry_response(existing) if existing
     end
 
-    private_class_method def self.create_entry(trip:, body:, **params)
+    private_class_method def self.create_entry(trip:, body:, user:, **params)
       result = JournalEntries::Create.new.call(
-        params: params.compact, trip: trip, user: resolve_jack_user
+        params: params.compact, trip: trip, user: user
       )
       case result
       in Dry::Monads::Success(entry)
@@ -96,7 +84,7 @@ module Tools
         id: entry.id, name: entry.name,
         entry_date: entry.entry_date.to_s,
         location_name: entry.location_name,
-        actor_type: entry.actor_type, trip_id: entry.trip_id
+        trip_id: entry.trip_id
       )
     end
   end

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -16,22 +16,31 @@ class TripJournalServer
     Tools::UploadJournalImages
   ].freeze
 
-  INSTRUCTIONS = <<~TEXT
-    You are Jack, an AI travel assistant for the Trip Journal app.
-    You can create and manage journal entries, attach images via URLs
-    or upload them directly as base64-encoded data, add comments and
-    reactions, update trip details, transition trip states, toggle
-    checklist items, and query trip status. When no trip_id is
-    provided, you operate on the single currently active (started) trip.
-  TEXT
-
   def self.build(server_context: {})
+    agent = server_context[:agent]
     MCP::Server.new(
       name: "trip_journal",
       version: "1.0.0",
-      instructions: INSTRUCTIONS,
+      instructions: instructions_for(agent),
       tools: TOOLS,
       server_context: server_context
     )
+  end
+
+  def self.instructions_for(agent)
+    persona =
+      if agent
+        "You are #{agent.name}, an AI travel assistant"
+      else
+        "You are an AI travel assistant"
+      end
+    <<~TEXT
+      #{persona} for the Trip Journal app.
+      You can create and manage journal entries, attach images via URLs
+      or upload them directly as base64-encoded data, add comments and
+      reactions, update trip details, transition trip states, toggle
+      checklist items, and query trip status. When no trip_id is
+      provided, you operate on the single currently active (started) trip.
+    TEXT
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Agent < ApplicationRecord
+  SLUG_FORMAT = /\A[a-z0-9_-]+\z/
+
+  belongs_to :user
+
+  validates :slug, presence: true,
+                   uniqueness: { case_sensitive: false },
+                   format: { with: SLUG_FORMAT }
+  validates :name, presence: true
+  validates :user_id, uniqueness: true
+
+  def self.by_slug(slug)
+    find_by("LOWER(slug) = ?", slug.to_s.downcase)
+  end
+end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -10,8 +10,19 @@ class Agent < ApplicationRecord
                    format: { with: SLUG_FORMAT }
   validates :name, presence: true
   validates :user_id, uniqueness: true
+  validate :user_must_be_system_actor
 
   def self.by_slug(slug)
     find_by("LOWER(slug) = ?", slug.to_s.downcase)
+  end
+
+  private
+
+  def user_must_be_system_actor
+    return unless user
+    return if user.system_actor?
+
+    errors.add(:user,
+               "must be a system actor (email ending in @system.local)")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,8 @@ class User < ApplicationRecord
   has_many :journal_entry_subscriptions, dependent: :destroy
 
   validates :email, presence: true, uniqueness: { case_sensitive: false }
+
+  def system_actor?
+    email.to_s.end_with?("@system.local")
+  end
 end

--- a/db/migrate/20260422100001_create_agents.rb
+++ b/db/migrate/20260422100001_create_agents.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateAgents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :agents, id: :uuid do |t|
+      t.string :slug, null: false
+      t.string :name, null: false
+      t.text :description
+      t.references :user, type: :uuid, null: false,
+                          foreign_key: true, index: { unique: true }
+      t.timestamps
+    end
+
+    add_index :agents, :slug, unique: true
+  end
+end

--- a/db/migrate/20260422100002_backfill_jack_agent.rb
+++ b/db/migrate/20260422100002_backfill_jack_agent.rb
@@ -2,8 +2,10 @@
 
 class BackfillJackAgent < ActiveRecord::Migration[8.1]
   def up
-    jack_user = User.find_by(email: "jack@system.local")
-    return unless jack_user
+    jack_user = User.find_or_create_by!(email: "jack@system.local") do |u|
+      u.name = "Jack"
+      u.status = 2 # Rodauth verified
+    end
 
     Agent.find_or_create_by!(slug: "jack") do |a|
       a.name = "Jack"

--- a/db/migrate/20260422100002_backfill_jack_agent.rb
+++ b/db/migrate/20260422100002_backfill_jack_agent.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class BackfillJackAgent < ActiveRecord::Migration[8.1]
+  def up
+    jack_user = User.find_by(email: "jack@system.local")
+    return unless jack_user
+
+    Agent.find_or_create_by!(slug: "jack") do |a|
+      a.name = "Jack"
+      a.user = jack_user
+    end
+  end
+
+  def down
+    Agent.find_by(slug: "jack")&.destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_19_134652) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_100002) do
   create_table "access_requests", id: uuid, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
@@ -59,6 +59,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_19_134652) do
     t.string "blob_id", limit: 36, null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "agents", id: uuid, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_id", limit: 36, null: false
+    t.index ["slug"], name: "index_agents_on_slug", unique: true
+    t.index ["user_id"], name: "index_agents_on_user_id", unique: true
   end
 
   create_table "checklist_items", id: uuid, force: :cascade do |t|
@@ -264,6 +275,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_19_134652) do
   add_foreign_key "access_requests", "users", column: "reviewed_by_id"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "agents", "users"
   add_foreign_key "checklist_items", "checklist_sections"
   add_foreign_key "checklist_sections", "checklists"
   add_foreign_key "checklists", "trips"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -79,6 +79,26 @@ jack = create_user(
 )
 log "System actor: #{jack.email}"
 
+maree = create_user(
+  email: "maree@system.local",
+  name: "Marée", roles: []
+)
+log "System actor: #{maree.email}"
+
+# ---------------------------------------------------------------------------
+# 1a. Agents (MCP identity layer)
+# ---------------------------------------------------------------------------
+
+Agent.find_or_create_by!(slug: "jack") do |a|
+  a.name = "Jack"
+  a.user = jack
+end
+Agent.find_or_create_by!(slug: "maree") do |a|
+  a.name = "Marée"
+  a.user = maree
+end
+log "Agents: #{Agent.pluck(:slug).join(', ')}"
+
 alice = create_user(
   email: "alice@acme.org",
   name: "Alice Martin", roles: [:contributor]

--- a/docs/mcp-curl-cheatsheet.md
+++ b/docs/mcp-curl-cheatsheet.md
@@ -22,7 +22,10 @@ The only three JSON-RPC methods the server understands are:
 Endpoint:     POST https://catalyst.workeverywhere.app/mcp
 Content-Type: application/json
 Auth:         Authorization: Bearer <MCP_API_KEY>
+Agent:        X-Agent-Identifier: <agent-slug>   (e.g. jack, maree)
 ```
+
+Both `Authorization` and `X-Agent-Identifier` are required. Missing bearer → HTTP 401. Missing/unknown agent → JSON-RPC `-32001` (200 OK with `error` in the body so the message is readable).
 
 ## Template
 
@@ -32,6 +35,7 @@ Every request follows this exact shape:
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "1",
@@ -85,6 +89,7 @@ Find the active trip and its stats. No arguments needed if exactly one trip is i
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "1",
@@ -107,6 +112,7 @@ With explicit trip:
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "2",
@@ -126,6 +132,7 @@ Optional: `trip_id`, `limit` (1-100, default 10), `offset` (default 0).
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "3",
@@ -142,7 +149,7 @@ curl -s https://catalyst.workeverywhere.app/mcp \
   }'
 ```
 
-Required: `name`, `entry_date`. Optional: `trip_id`, `body` (HTML), `location_name`, `description`, `actor_type` (default "Jack"), `actor_id` (default "jack").
+Required: `name`, `entry_date`. Optional: `trip_id`, `body` (HTML), `location_name`, `description`, `telegram_message_id`. Attribution is derived from the `X-Agent-Identifier` header — not a tool parameter.
 
 ### Update Journal Entry
 
@@ -150,6 +157,7 @@ Required: `name`, `entry_date`. Optional: `trip_id`, `body` (HTML), `location_na
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "4",
@@ -172,6 +180,7 @@ Required: `journal_entry_id` + at least one of `name`, `body`, `entry_date`, `lo
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "5",
@@ -197,6 +206,7 @@ Max 5 URLs per call, HTTPS only, 10MB per image, jpeg/png/webp/gif.
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "6",
@@ -222,6 +232,7 @@ Max 5 images per call, 10MB each. `filename` is optional (auto-generated from MI
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "7",
@@ -244,6 +255,7 @@ Toggle an emoji on a journal entry. Call again to remove.
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "8",
@@ -266,6 +278,7 @@ Allowed emojis: `thumbsup`, `heart`, `tada`, `eyes`, `fire`, `rocket`.
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "9",
@@ -286,6 +299,7 @@ curl -s https://catalyst.workeverywhere.app/mcp \
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "10",
@@ -307,6 +321,7 @@ Valid states: `planning`, `started`, `finished`, `cancelled`, `archived`. Transi
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "11",
@@ -324,6 +339,7 @@ curl -s https://catalyst.workeverywhere.app/mcp \
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{
     "jsonrpc": "2.0",
     "id": "12",
@@ -361,6 +377,7 @@ export MCP_API_KEY="your-key-here"
 curl -s https://catalyst.workeverywhere.app/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
   -d '{"jsonrpc":"2.0","id":"test","method":"tools/list"}' \
   | python3 -c "import json,sys; tools=json.load(sys.stdin)['result']['tools']; print(f'{len(tools)} tools:'); [print(f'  - {t[\"name\"]}') for t in tools]"
 ```

--- a/prompts/Phase 19 - Agent Identity - Phase 1 - Code Review.md
+++ b/prompts/Phase 19 - Agent Identity - Phase 1 - Code Review.md
@@ -1,0 +1,125 @@
+# CODE REVIEW
+
+The CI is RED, please investigate and fix the CI.
+Once the CI Green, go through the PR comments and share your thoughts.
+DO NOT FIX IT, give your thoughts first, and wait confirmation.
+BTW: I've noticed there were no system tests added, is it on purpose?
+
+Codex Comment 1 (P1) — Backfill should create Jack when missing
+
+  File: db/migrate/20260422100002_backfill_jack_agent.rb:6
+  Claim: migration no-ops if jack@system.local doesn't exist, leaving the agents table empty and every MCP request failing -32001.
+
+  My take: valid, accept the fix
+
+  - Production today: the Jack user exists (verified — the migration actually migrated a real record when I ran it locally, not a no-op), so this is abstract for our prod. But codex is correct that
+  in any environment where jack@system.local is missing (a freshly initialised test env, a new developer machine before db:seed, a hypothetical future staging clone), the migration silently leaves
+  the server in a state where every MCP call errors out.
+  - Why I wrote it this way: I treated seeds as the source of Jack, and the migration as "only wrap what exists." That's a split responsibility that's fine on paper but fragile in practice.
+  - Cleanest fix: have the migration bootstrap the Jack user + agent unconditionally (both via find_or_create_by!). The seed file's Jack block then becomes a no-op in any environment that already ran
+   migrations — which is every environment. That makes the migration self-sufficient and keeps seeds idempotent.
+  - Tradeoff: the migration grows a few lines and duplicates one line of seed logic (u.status = 2 for Rodauth verified). I think that's the right call — the migration is the production safety net;
+  seeds are a dev/test convenience.
+
+  Confidence: high. Would write it the same way on a second pass.
+
+  ---
+  Codex Comment 2 (P2) — Agent model should validate system-actor User
+
+  File: app/models/agent.rb:12
+  Claim: model lets any User be attached to an Agent. If a human user is linked, writes get attributed to them and they get auto-subscribed (because subscribe_trip_members only filters by
+  @system.local email), so a human would start receiving notifications for their own bot-like writes.
+
+  My take: valid, accept the fix
+
+  - How real is this? Low likelihood in practice — only Rails console can mis-wire this today, and whoever runs it is you. But the model's job is to encode invariants, and the PRP (§4 gotcha #3)
+  literally says "Marée's email must end with @system.local or she auto-subscribes." Codex is pointing out that this invariant lives only in documentation + the seed file, not in the code.
+  - Nice consequence: if I ever refactor the subscription filter off the email suffix (e.g., to a User#system_actor? method), the invariant stays in one place.
+  - Cleanest fix: add a validation on Agent that user.email ends with @system.local. Optional polish: extract User#system_actor? as a method and use it in both the validation and
+  JournalEntries::Create#subscribe_trip_members. That's a tiny refactor but probably out of scope for Phase 1 — just the Agent validation is enough to address the review.
+  - Tradeoff: the validation couples Agent to a User convention. Someone who wants to change the convention later has to update Agent too. I think that's correct coupling, not accidental.
+
+  Confidence: high. I'd actually weigh this as P1-adjacent — it's the kind of latent bug that ships quietly and surfaces as "why am I getting Jack's emails?"
+
+  ---
+  Your question — "no system tests added, is it on purpose?"
+
+  Mostly on purpose, partially lazy. Mix of both.
+
+  What the changes actually are: entirely MCP-backend. New controller path, new model, new server plumbing, Phase 1.5 cleanup. No new UI surface (no admin page, no agent dropdown, no new flash
+  messages).
+
+  Coverage I did add:
+  - spec/models/agent_spec.rb — 11 specs (validations, slug matching, associations).
+  - spec/requests/mcp_spec.rb — full HTTP cycle through the controller, including new -32001 branches and personalised instructions assertion.
+  - spec/mcp/tools/*_spec.rb — each write tool asserts attribution to agent.user.
+  - Live curl + DB check during runtime verification.
+
+  What system tests would genuinely catch:
+  - If the feed / trip page / notification UI ever had "Jack" hardcoded, a system test exercising the UI after a Marée-authored entry would surface it. But the views already read user.name
+  dynamically — no hardcoded Jack in the rendered output. A system test there would be testing Rails more than it tests my change.
+  - The one place a system test could earn its keep is a regression guard: log in, visit the trips feed, assert that an entry authored by a Marée agent renders "Marée" as the author label. That's
+  cheap (~10 lines) and would catch a future refactor that accidentally hardcodes a name.
+
+  Why I skipped it:
+  - YAGNI judgment call: the existing request specs + live curl + DB attribution check prove the attribution works end-to-end.
+  - No UI changes in this PR, so no new UI surface to regression-test.
+  - Agent management is Rails-console-only for Phase 1; the admin page is Phase 2 material, where system tests become genuinely necessary.
+
+  Where I think you're right to push back:
+  - The feed-rendering system test I described (10 lines, asserts a Marée entry shows "Marée") would be a cheap insurance policy. It doesn't catch a real bug today but it's a regression guard for
+  when the rendering code changes. If you want defense-in-depth, adding it is the right call.
+  - I could also argue the absence of a system test for the Account sign-out page is why the ambiguous-match regression on main went unnoticed — but that's a different test owner.
+
+  Verdict: I have a reasonable YAGNI defence, but I'd accept "add one feed-rendering system test for Marée attribution" as a reasonable ask. Let me know.
+
+  ---
+  Proposed next steps (awaiting your go-ahead)
+
+  1. Apply codex P1 — rewrite backfill_jack_agent migration to also create the Jack user if missing, so the migration is self-sufficient.
+  2. Apply codex P2 — add validates :user system-actor check on Agent (optionally extract User#system_actor?).
+  3. Optional: add one system test exercising the feed with a Marée-authored entry, as a regression guard.
+  4. Reply to both codex comments on GitHub explaining what was done + which commit, then resolve both threads.
+
+  Which of 1/2/3 do you want me to action? Reply-and-resolve (step 4) happens either way once the fixes land.
+
+  CI green on round 2. All three fixes in, threads resolved.
+
+  Round 2 commits (on top of original Phase 19)
+
+  ┌─────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+  │   SHA   │                                                            What                                                            │
+  ├─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ b2d487f │ CI fix — scope Account sign-out click to <main> (pre-existing main-branch failure, unrelated to Phase 19)                  │
+  ├─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ 285ce6e │ P2 — User#system_actor? + Agent validation + refactor subscribe_trip_members to use the new method                         │
+  ├─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ 1033943 │ P1 — BackfillJackAgent is self-sufficient (find_or_create_by! on Jack user, not just the agent)                            │
+  ├─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ 2b07613 │ System test + factory fix — Marée-authored entry renders "Marée" in feed; agent factory now propagates name into user.name │
+  ├─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+  │ 8c4fd3c │ Steps.md audit trail — both review rounds logged                                                                           │
+  └─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+  Codex threads
+
+  - https://github.com/joel/trip/pull/117#discussion_r3123585034 → resolved
+  - https://github.com/joel/trip/pull/117#discussion_r3123585200 → resolved
+
+  Test counts
+
+  - Unit/request: 636 → 640 (+4 from User#system_actor? + Agent non-system-actor validation)
+  - System: 78 → 79 (+1 for Marée feed attribution)
+  - Lint: clean
+
+  Bonus bug caught by the system test
+
+  While writing the feed-rendering test, I discovered the original agent factory set user.name = "System Actor" generically, so any test using the factory would have had a mismatched agent.name vs
+  user.name. In production this is fine because seeds and the backfill migration both set them in sync, but the factory was silently lying. Fixed in 2b07613 so user.name tracks agent.name by default
+  — your hunch about adding system tests already paid for itself.
+
+  Ready for your second-round review on PR #117, or merge when you're satisfied.
+
+● Monitor "PR 117 CI final result (round 2)" stream ended
+
+● Monitor cleanup — no action needed, round 2 summary already sent above.

--- a/prompts/Phase 19 - Agent Identity - Phase 1 - Code Review.md
+++ b/prompts/Phase 19 - Agent Identity - Phase 1 - Code Review.md
@@ -123,3 +123,6 @@ Codex Comment 1 (P1) — Backfill should create Jack when missing
 ● Monitor "PR 117 CI final result (round 2)" stream ended
 
 ● Monitor cleanup — no action needed, round 2 summary already sent above.
+
+Resume this session with:
+claude --resume 84920a3e-3b53-4d7a-8aa1-b0fd4aa332c8

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -24,6 +24,7 @@
 
 1. `10cf542` — Introduce Agent model + migrations + specs + `:system_actor` user factory trait + Phase 19 Steps.md.
 2. `aac8f83` — Wire agent identity through MCP stack: controller reads `X-Agent-Identifier`, server templates instructions, base_tool exposes `resolve_agent_user`, write-path tools pipe server_context through, Phase 1.5 cleanup drops `actor_type`/`actor_id` params + `VALID_ACTOR_TYPES`. Specs updated.
+3. `09d192a` — Seed Marée system user and both Agent records (idempotent).
 
 ## 4. Runtime verification
 

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -43,7 +43,9 @@
 
 ## 5. PR + review
 
-_TBD_
+- **PR:** [#117 — Phase 19 Phase 1 — Agent Identity (Registered Agents)](https://github.com/joel/trip/pull/117) (branch: `feature/phase19-agent-identity`, closes #116).
+- **Kanban:** card move to **In Review** deferred — `gh auth` missing `read:project`/`write:project` scopes. Maintainer to move manually or run `gh auth refresh -s read:project,project`.
+- **Reviews:** _TBD_
 
 ## 6. Final summary
 

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -23,6 +23,7 @@
 ## 3. Commits
 
 1. `10cf542` — Introduce Agent model + migrations + specs + `:system_actor` user factory trait + Phase 19 Steps.md.
+2. `aac8f83` — Wire agent identity through MCP stack: controller reads `X-Agent-Identifier`, server templates instructions, base_tool exposes `resolve_agent_user`, write-path tools pipe server_context through, Phase 1.5 cleanup drops `actor_type`/`actor_id` params + `VALID_ACTOR_TYPES`. Specs updated.
 
 ## 4. Runtime verification
 

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -45,7 +45,23 @@
 
 - **PR:** [#117 — Phase 19 Phase 1 — Agent Identity (Registered Agents)](https://github.com/joel/trip/pull/117) (branch: `feature/phase19-agent-identity`, closes #116).
 - **Kanban:** card move to **In Review** deferred — `gh auth` missing `read:project`/`write:project` scopes. Maintainer to move manually or run `gh auth refresh -s read:project,project`.
-- **Reviews:** _TBD_
+
+### Round 1 — CI fix
+
+- **CI red on first push:** `spec/system/accounts_spec.rb:29` (`Capybara::Ambiguous` — two visible "Sign out" buttons: sidebar + Account page header). Pre-existing on main (commit `4a79475` was already failing with the same error), unrelated to Phase 19.
+- `b2d487f` — Scope the click to `within("main")` so the Account-page button wins over the sidebar link.
+
+### Round 2 — Codex review
+
+| Finding | Severity | Action | Commit |
+|---------|----------|--------|--------|
+| `agents` table can be empty in cold-start envs (`BackfillJackAgent` no-ops when Jack user absent) | P1 | Migration now `find_or_create_by!`s the Jack user itself — self-sufficient in any environment that has run migrations | `1033943` |
+| `Agent` allows non-system-actor User → human accidentally attributed/auto-subscribed | P2 | Added `User#system_actor?`, Agent validation, refactored `JournalEntries::Create#subscribe_trip_members` to use the method | `285ce6e` |
+| Feedback: no system test covers agent attribution in the UI | — | Added spec asserting Marée-authored entry renders "Marée" in feed card; tightened agent factory so user.name tracks agent.name by default | `2b07613` |
+
+Both codex threads replied and resolved (`https://github.com/joel/trip/pull/117#discussion_r3123585034`, `r3123585200`).
+
+- **Final validation:** lint clean, 640 unit/request specs green, 79 system specs green (+1 new system test for agent attribution, +4 new model specs from P2).
 
 ## 6. Final summary
 

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -25,10 +25,21 @@
 1. `10cf542` — Introduce Agent model + migrations + specs + `:system_actor` user factory trait + Phase 19 Steps.md.
 2. `aac8f83` — Wire agent identity through MCP stack: controller reads `X-Agent-Identifier`, server templates instructions, base_tool exposes `resolve_agent_user`, write-path tools pipe server_context through, Phase 1.5 cleanup drops `actor_type`/`actor_id` params + `VALID_ACTOR_TYPES`. Specs updated.
 3. `09d192a` — Seed Marée system user and both Agent records (idempotent).
+4. `85b1c1f` — Update MCP docs across AGENTS.md, README.md, app/mcp/README.md, curl cheatsheet, and the trip-journal-mcp skill; drop `actor_type`/`actor_id` and Jack-as-sole-actor language.
 
 ## 4. Runtime verification
 
-_TBD_
+- `bin/cli app rebuild` → container up, `GET /up` returns 200.
+- `mise x -- bundle exec rake project:lint` → clean (436 files, 0 offenses).
+- `mise x -- bundle exec rake project:tests` → 636 examples, 0 failures, 2 pending (pre-existing).
+- `mise x -- bundle exec rake project:system-tests` → 78 examples, 0 failures.
+- **curl smoke tests against `https://catalyst.workeverywhere.docker/mcp`:**
+  - No `X-Agent-Identifier` header → JSON-RPC `-32001`, message *"Missing X-Agent-Identifier header…"*.
+  - `X-Agent-Identifier: jack` → 12 tools returned.
+  - `X-Agent-Identifier: ghost` → JSON-RPC `-32001`, message *"Agent 'ghost' is not registered…"*.
+  - `X-Agent-Identifier: maree` + `initialize` → instructions begin *"You are Marée, an AI travel assistant for the Trip Journal app…"*.
+- **End-to-end attribution**: `create_journal_entry` with `X-Agent-Identifier: maree` → new `JournalEntry#author` is `Marée <maree@system.local>`, not Jack.
+- **Browser sweep**: `https://catalyst.workeverywhere.docker/` home page renders cleanly (screenshot `tmp/phase19/01_home.png`). Phase 1 has no UI surface; the render check confirms the Agent autoload + migration didn't break the boot path.
 
 ## 5. PR + review
 

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -22,7 +22,7 @@
 
 ## 3. Commits
 
-_TBD_
+1. `10cf542` — Introduce Agent model + migrations + specs + `:system_actor` user factory trait + Phase 19 Steps.md.
 
 ## 4. Runtime verification
 

--- a/prompts/Phase 19 - Steps.md
+++ b/prompts/Phase 19 - Steps.md
@@ -1,0 +1,37 @@
+# Phase 19 — Steps (audit trail)
+
+> Append-only log of decisions, commits, and verifications.
+> Plan: [`prompts/Phase 19 - Agent Identity - Phase 1 - PRP.md`](Phase%2019%20-%20Agent%20Identity%20-%20Phase%201%20-%20PRP.md).
+> Brainstorm: [`prompts/Phase 19 - Agent Identity Brainstorming.md`](Phase%2019%20-%20Agent%20Identity%20Brainstorming.md).
+
+---
+
+## 1. Issue + plan
+
+- **Issue:** [#116 — Phase 19 Phase 1 — Agent Identity (Registered Agents)](https://github.com/joel/trip/issues/116) (label: `enhancement`).
+- **Plan:** `prompts/Phase 19 - Agent Identity - Phase 1 - PRP.md`.
+- **User approved the plan.**
+
+## 1a. Kanban
+
+- **Blocked on scope:** `gh auth` keyring token is missing `read:project` / `write:project`. Kanban card transitions (Backlog → Ready → In Progress → In Review → Done) must be done manually this phase, or after `gh auth refresh -s read:project,project`.
+
+## 2. Branch
+
+- `feature/phase19-agent-identity` (off `main`).
+
+## 3. Commits
+
+_TBD_
+
+## 4. Runtime verification
+
+_TBD_
+
+## 5. PR + review
+
+_TBD_
+
+## 6. Final summary
+
+_TBD_

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  sequence(:agent_slug) { |n| "agent#{n}" }
+
+  factory :agent do
+    slug { generate(:agent_slug) }
+    name { slug.capitalize }
+    user factory: %i[user system_actor]
+  end
+end

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -6,6 +6,9 @@ FactoryBot.define do
   factory :agent do
     slug { generate(:agent_slug) }
     name { slug.capitalize }
-    user factory: %i[user system_actor]
+
+    user do
+      association(:user, :system_actor, name: name)
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,8 @@
 FactoryBot.define do
   sequence(:email) { |n| "user#{n}@example.com" }
 
+  sequence(:system_actor_email) { |n| "agent#{n}@system.local" }
+
   factory :user do
     name { "MyString" }
     email { generate(:email) }
@@ -17,6 +19,11 @@ FactoryBot.define do
 
     trait :viewer do
       roles { [:viewer] }
+    end
+
+    trait :system_actor do
+      email { generate(:system_actor_email) }
+      name { "System Actor" }
     end
   end
 end

--- a/spec/mcp/tools/add_reaction_spec.rb
+++ b/spec/mcp/tools/add_reaction_spec.rb
@@ -4,25 +4,33 @@ require "rails_helper"
 
 RSpec.describe Tools::AddReaction do
   let(:entry) { create(:journal_entry) }
+  let(:agent) { create(:agent) }
+  let(:context) { { agent: agent } }
 
   describe ".call" do
-    it "adds a reaction to a journal entry" do
+    it "adds a reaction attributed to the agent's user" do
       result = described_class.call(
-        journal_entry_id: entry.id, emoji: "thumbsup"
+        journal_entry_id: entry.id, emoji: "thumbsup",
+        server_context: context
       )
 
       data = JSON.parse(result.content.first[:text])
       expect(data["action"]).to eq("added")
       expect(data["emoji"]).to eq("thumbsup")
+
+      reaction = Reaction.find(data["id"])
+      expect(reaction.user).to eq(agent.user)
     end
 
     it "removes a reaction when toggled twice" do
       described_class.call(
-        journal_entry_id: entry.id, emoji: "thumbsup"
+        journal_entry_id: entry.id, emoji: "thumbsup",
+        server_context: context
       )
 
       result = described_class.call(
-        journal_entry_id: entry.id, emoji: "thumbsup"
+        journal_entry_id: entry.id, emoji: "thumbsup",
+        server_context: context
       )
 
       data = JSON.parse(result.content.first[:text])
@@ -33,7 +41,8 @@ RSpec.describe Tools::AddReaction do
       entry.trip.update!(state: :archived)
 
       result = described_class.call(
-        journal_entry_id: entry.id, emoji: "thumbsup"
+        journal_entry_id: entry.id, emoji: "thumbsup",
+        server_context: context
       )
 
       expect(result.error?).to be true
@@ -42,7 +51,8 @@ RSpec.describe Tools::AddReaction do
 
     it "returns error for nonexistent journal entry" do
       result = described_class.call(
-        journal_entry_id: "nonexistent", emoji: "thumbsup"
+        journal_entry_id: "nonexistent", emoji: "thumbsup",
+        server_context: context
       )
 
       expect(result.error?).to be true

--- a/spec/mcp/tools/create_comment_spec.rb
+++ b/spec/mcp/tools/create_comment_spec.rb
@@ -4,23 +4,30 @@ require "rails_helper"
 
 RSpec.describe Tools::CreateComment do
   let(:entry) { create(:journal_entry) }
+  let(:agent) { create(:agent) }
+  let(:context) { { agent: agent } }
 
   describe ".call" do
-    it "creates a comment on the journal entry" do
+    it "creates a comment on the journal entry attributed to the agent" do
       result = described_class.call(
-        journal_entry_id: entry.id, body: "Great photo!"
+        journal_entry_id: entry.id, body: "Great photo!",
+        server_context: context
       )
 
       data = JSON.parse(result.content.first[:text])
       expect(data["body"]).to eq("Great photo!")
       expect(data["journal_entry_id"]).to eq(entry.id)
+
+      comment = Comment.find(data["id"])
+      expect(comment.user).to eq(agent.user)
     end
 
     it "rejects comments on non-commentable trips" do
       entry.trip.update!(state: :archived)
 
       result = described_class.call(
-        journal_entry_id: entry.id, body: "Should fail"
+        journal_entry_id: entry.id, body: "Should fail",
+        server_context: context
       )
 
       expect(result.error?).to be true
@@ -30,13 +37,15 @@ RSpec.describe Tools::CreateComment do
     it "returns idempotent response for duplicate telegram_message_id" do
       first = described_class.call(
         journal_entry_id: entry.id, body: "First",
-        telegram_message_id: "tg-456"
+        telegram_message_id: "tg-456",
+        server_context: context
       )
       first_data = JSON.parse(first.content.first[:text])
 
       second = described_class.call(
         journal_entry_id: entry.id, body: "Second",
-        telegram_message_id: "tg-456"
+        telegram_message_id: "tg-456",
+        server_context: context
       )
       second_data = JSON.parse(second.content.first[:text])
 
@@ -45,7 +54,8 @@ RSpec.describe Tools::CreateComment do
 
     it "returns error for nonexistent journal entry" do
       result = described_class.call(
-        journal_entry_id: "nonexistent", body: "Hello"
+        journal_entry_id: "nonexistent", body: "Hello",
+        server_context: context
       )
 
       expect(result.error?).to be true

--- a/spec/mcp/tools/create_journal_entry_spec.rb
+++ b/spec/mcp/tools/create_journal_entry_spec.rb
@@ -4,31 +4,31 @@ require "rails_helper"
 
 RSpec.describe Tools::CreateJournalEntry do
   let!(:trip) { create(:trip, :started) }
+  let(:agent) { create(:agent) }
+  let(:context) { { agent: agent } }
 
   describe ".call" do
-    it "creates a journal entry with actor attribution" do
+    it "creates a journal entry attributed to the agent's user" do
       result = described_class.call(
         name: "Day 1 in Paris",
         entry_date: Date.current.to_s,
         trip_id: trip.id,
-        actor_type: "Jack",
-        actor_id: "jack"
+        server_context: context
       )
 
       expect(result).to be_a(MCP::Tool::Response)
       data = JSON.parse(result.content.first[:text])
       expect(data["name"]).to eq("Day 1 in Paris")
-      expect(data["actor_type"]).to eq("Jack")
 
       entry = JournalEntry.find(data["id"])
-      expect(entry.actor_type).to eq("Jack")
-      expect(entry.actor_id).to eq("jack")
-      expect(entry.author.email).to eq("jack@system.local")
+      expect(entry.author).to eq(agent.user)
+      expect(entry.author.email).to eq(agent.user.email)
     end
 
     it "resolves active trip when trip_id is omitted" do
       result = described_class.call(
-        name: "Auto-resolved", entry_date: Date.current.to_s
+        name: "Auto-resolved", entry_date: Date.current.to_s,
+        server_context: context
       )
 
       data = JSON.parse(result.content.first[:text])
@@ -39,7 +39,8 @@ RSpec.describe Tools::CreateJournalEntry do
       trip.update!(state: :planning)
 
       result = described_class.call(
-        name: "No trip", entry_date: Date.current.to_s
+        name: "No trip", entry_date: Date.current.to_s,
+        server_context: context
       )
 
       expect(result.error?).to be true
@@ -51,7 +52,8 @@ RSpec.describe Tools::CreateJournalEntry do
 
       result = described_class.call(
         name: "Should fail", entry_date: Date.current.to_s,
-        trip_id: cancelled_trip.id
+        trip_id: cancelled_trip.id,
+        server_context: context
       )
 
       expect(result.error?).to be true
@@ -61,18 +63,30 @@ RSpec.describe Tools::CreateJournalEntry do
     it "returns idempotent response for duplicate telegram_message_id" do
       first = described_class.call(
         name: "Telegram entry", entry_date: Date.current.to_s,
-        trip_id: trip.id, telegram_message_id: "tg-123"
+        trip_id: trip.id, telegram_message_id: "tg-123",
+        server_context: context
       )
       first_data = JSON.parse(first.content.first[:text])
 
       second = described_class.call(
         name: "Different name", entry_date: Date.current.to_s,
-        trip_id: trip.id, telegram_message_id: "tg-123"
+        trip_id: trip.id, telegram_message_id: "tg-123",
+        server_context: context
       )
       second_data = JSON.parse(second.content.first[:text])
 
       expect(second_data["id"]).to eq(first_data["id"])
       expect(JournalEntry.where(telegram_message_id: "tg-123").count).to eq(1)
+    end
+
+    it "returns error when server_context lacks an agent" do
+      result = described_class.call(
+        name: "Orphaned", entry_date: Date.current.to_s,
+        trip_id: trip.id, server_context: {}
+      )
+
+      expect(result.error?).to be true
+      expect(result.content.first[:text]).to include("No agent in server context")
     end
   end
 end

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -26,9 +26,18 @@ RSpec.describe TripJournalServer do
         Tools::UploadJournalImages
       )
     end
+  end
 
-    it "includes server instructions" do
-      expect(described_class::INSTRUCTIONS).to include("Jack")
+  describe ".instructions_for" do
+    it "personalises the instructions with the agent's name" do
+      agent = build(:agent, name: "Marée")
+      expect(described_class.instructions_for(agent))
+        .to include("You are Marée")
+    end
+
+    it "falls back to generic phrasing when no agent is given" do
+      expect(described_class.instructions_for(nil))
+        .to include("You are an AI travel assistant")
     end
   end
 end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Agent do
       expect(dup).not_to be_valid
       expect(dup.errors[:user_id]).to include("has already been taken")
     end
+
+    it "rejects a non-system-actor user" do
+      human = create(:user, email: "human@example.com")
+      agent = build(:agent, user: human)
+      expect(agent).not_to be_valid
+      expect(agent.errors[:user].join)
+        .to include("system actor", "@system.local")
+    end
   end
 
   describe ".by_slug" do

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Agent do
+  describe "validations" do
+    subject(:agent) { build(:agent) }
+
+    it { is_expected.to be_valid }
+
+    it "requires a slug" do
+      agent.slug = nil
+      expect(agent).not_to be_valid
+      expect(agent.errors[:slug]).to include("can't be blank")
+    end
+
+    it "requires a name" do
+      agent.name = nil
+      expect(agent).not_to be_valid
+      expect(agent.errors[:name]).to include("can't be blank")
+    end
+
+    it "enforces slug format (lowercase, digits, hyphen, underscore)" do
+      ["Jack", "jack!", "jack.1", "jack space"].each do |bad|
+        agent.slug = bad
+        expect(agent).not_to be_valid,
+                             "expected #{bad.inspect} to be invalid"
+      end
+      %w[jack maree jack-2 trip_bot agent_01].each do |good|
+        agent.slug = good
+        expect(agent).to be_valid, "expected #{good.inspect} to be valid"
+      end
+    end
+
+    it "enforces slug uniqueness case-insensitively" do
+      create(:agent, slug: "jack")
+      dup = build(:agent, slug: "JACK")
+      expect(dup).not_to be_valid
+      expect(dup.errors[:slug]).to include("has already been taken")
+    end
+
+    it "enforces one agent per user" do
+      shared_user = create(:user, :system_actor)
+      create(:agent, user: shared_user)
+      dup = build(:agent, user: shared_user)
+      expect(dup).not_to be_valid
+      expect(dup.errors[:user_id]).to include("has already been taken")
+    end
+  end
+
+  describe ".by_slug" do
+    let!(:agent) { create(:agent, slug: "maree") }
+
+    it "matches an exact slug" do
+      expect(described_class.by_slug("maree")).to eq(agent)
+    end
+
+    it "matches case-insensitively" do
+      expect(described_class.by_slug("MAREE")).to eq(agent)
+    end
+
+    it "returns nil for an unknown slug" do
+      expect(described_class.by_slug("ghost")).to be_nil
+    end
+
+    it "returns nil for blank input" do
+      expect(described_class.by_slug("")).to be_nil
+      expect(described_class.by_slug(nil)).to be_nil
+    end
+  end
+
+  describe "associations" do
+    it "belongs to a user" do
+      agent = create(:agent)
+      expect(agent.user).to be_a(User)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe User do
     end
   end
 
+  describe "#system_actor?" do
+    it "returns true for @system.local emails" do
+      user = described_class.new(email: "maree@system.local",
+                                 name: "Marée")
+      expect(user.system_actor?).to be(true)
+    end
+
+    it "returns false for regular emails" do
+      user = described_class.new(email: "alice@acme.org",
+                                 name: "Alice")
+      expect(user.system_actor?).to be(false)
+    end
+
+    it "is safe for nil email" do
+      user = described_class.new(name: "Unsaved")
+      expect(user.system_actor?).to be(false)
+    end
+  end
+
   describe "notification cleanup on destroy" do
     it "destroys actor-side notifications when user is deleted" do
       actor = create(:user)

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe "MCP Endpoint" do
   let(:api_key) { "test-mcp-api-key" }
+  let!(:agent) { create(:agent, slug: "jack", name: "Jack") }
 
   before do
     allow(ENV).to receive(:fetch).and_call_original
@@ -14,7 +15,8 @@ RSpec.describe "MCP Endpoint" do
     let(:headers) do
       {
         "Authorization" => "Bearer #{api_key}",
-        "Content-Type" => "application/json"
+        "Content-Type" => "application/json",
+        "X-Agent-Identifier" => agent.slug
       }
     end
 
@@ -79,7 +81,32 @@ RSpec.describe "MCP Endpoint" do
       end
     end
 
-    context "with valid API key" do
+    context "without X-Agent-Identifier header" do
+      it "returns JSON-RPC error -32001 with a helpful message" do
+        post "/mcp", params: init_payload,
+                     headers: headers.except("X-Agent-Identifier")
+        expect(response).to have_http_status(:ok)
+
+        body = response.parsed_body
+        expect(body["error"]["code"]).to eq(-32_001)
+        expect(body["error"]["message"])
+          .to include("X-Agent-Identifier")
+      end
+    end
+
+    context "with unknown agent slug" do
+      it "returns JSON-RPC error -32001 with the slug echoed back" do
+        post "/mcp", params: init_payload,
+                     headers: headers.merge("X-Agent-Identifier" => "ghost")
+        expect(response).to have_http_status(:ok)
+
+        body = response.parsed_body
+        expect(body["error"]["code"]).to eq(-32_001)
+        expect(body["error"]["message"]).to include("'ghost'")
+      end
+    end
+
+    context "with valid API key and agent" do
       it "responds to initialize request" do
         post "/mcp", params: init_payload, headers: headers
         expect(response).to have_http_status(:ok)
@@ -87,6 +114,13 @@ RSpec.describe "MCP Endpoint" do
         body = response.parsed_body
         expect(body["result"]["serverInfo"]["name"])
           .to eq("trip_journal")
+      end
+
+      it "personalises instructions with the resolved agent name" do
+        post "/mcp", params: init_payload, headers: headers
+
+        instructions = response.parsed_body["result"]["instructions"]
+        expect(instructions).to include("You are Jack")
       end
 
       it "lists all 12 tools" do
@@ -110,32 +144,31 @@ RSpec.describe "MCP Endpoint" do
         )
       end
 
-      it "executes tools/call and creates a journal entry" do # rubocop:disable RSpec/ExampleLength
+      it "executes tools/call and creates a journal entry " \
+         "attributed to the agent" do
         trip = create(:trip, :started)
         post "/mcp", params: init_payload, headers: headers
 
-        call_payload = {
-          jsonrpc: "2.0", id: "3",
-          method: "tools/call",
+        expect { post("/mcp", params: create_entry_call(trip), headers: headers) }
+          .to change(JournalEntry, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        data = JSON.parse(response.parsed_body["result"]["content"].first["text"])
+        expect(data["name"]).to eq("MCP Test Entry")
+        expect(JournalEntry.find(data["id"]).author).to eq(agent.user)
+      end
+
+      def create_entry_call(trip)
+        {
+          jsonrpc: "2.0", id: "3", method: "tools/call",
           params: {
             name: "create_journal_entry",
             arguments: {
-              trip_id: trip.id,
-              name: "MCP Test Entry",
+              trip_id: trip.id, name: "MCP Test Entry",
               entry_date: Date.current.to_s
             }
           }
         }.to_json
-
-        expect do
-          post "/mcp", params: call_payload, headers: headers
-        end.to change(JournalEntry, :count).by(1)
-
-        expect(response).to have_http_status(:ok)
-        content = response.parsed_body["result"]["content"]
-        data = JSON.parse(content.first["text"])
-        expect(data["name"]).to eq("MCP Test Entry")
-        expect(data["trip_id"]).to eq(trip.id)
       end
     end
   end

--- a/spec/system/accounts_spec.rb
+++ b/spec/system/accounts_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe "Accounts" do
 
   it "signs the user out from the account page" do
     visit account_path
-    expect(page).to have_button("Sign out")
-    click_on "Sign out"
+    within("main") do
+      expect(page).to have_button("Sign out")
+      click_on "Sign out"
+    end
     expect(page).to have_content("Welcome to Catalyst")
   end
 end

--- a/spec/system/journal_entries_spec.rb
+++ b/spec/system/journal_entries_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe "Journal Entries Feed Wall" do
     expect(page).to have_content("New Title")
   end
 
+  it "attributes agent-authored entries to the agent's display name" do
+    maree = create(:agent, slug: "maree", name: "Marée")
+    create(:journal_entry, trip: trip, author: maree.user,
+                           name: "Visited Mont Saint-Michel")
+
+    visit trip_path(trip)
+
+    within "article", text: "Visited Mont Saint-Michel" do
+      expect(page).to have_content("Marée")
+    end
+  end
+
   it "deletes a journal entry from the trip page", :js do
     entry = create(:journal_entry, trip: trip, author: admin,
                                    name: "Deletable")


### PR DESCRIPTION
## Summary

Introduces a first-class `Agent` model so MCP clients identify themselves via `X-Agent-Identifier` on each request, replacing the hardcoded "Jack" attribution. Bundles Phase 1.5 cleanup — drops `actor_type`/`actor_id` tool params, `VALID_ACTOR_TYPES`, and `validate_actor_type!`.

- **New data layer:** `agents(slug, name, description, user_id)` table with `Agent belongs_to :user`. Slugs are lowercase, case-insensitively unique. Each Agent owns exactly one `@system.local` User.
- **New controller layer:** `McpController` reads `X-Agent-Identifier`, resolves to an Agent, injects into `server_context`. Missing/unknown slug → JSON-RPC `-32001` (HTTP 200 with readable message — not opaque 401).
- **Server:** `TripJournalServer.instructions_for(agent)` templates the persona — "You are Marée, an AI travel assistant…" vs. "You are Jack, …".
- **Write tools:** `create_journal_entry`, `create_comment`, `add_reaction` pipe the resolved agent's user through `resolve_agent_user(server_context)`.
- **Data migration:** idempotent `BackfillJackAgent` wraps existing `jack@system.local` user in `Agent(slug: "jack", name: "Jack")` — production-safe, no-ops when Jack user is absent.
- **Seeds:** add Marée user + both Agent records.
- **Docs:** AGENTS.md, README.md, app/mcp/README.md, the curl cheatsheet, and the trip-journal-mcp skill all updated to describe the two-layer auth model (Bearer token for the channel + agent header for attribution).

## Out of Scope

- Phase 2 per-trip pairing keys.
- Phase 3 OAuth.
- Admin UI (Rails console + seeds cover it for two agents).
- Dropping the now-unused `journal_entries.actor_type` / `actor_id` columns (historical data — schedule a later cleanup migration).
- Changing `MCP_API_KEY` Bearer-token auth (unchanged).

## Plan

See `prompts/Phase 19 - Agent Identity - Phase 1 - PRP.md` for the full PRP and `prompts/Phase 19 - Steps.md` for the audit trail (commit-by-commit log + runtime verification).

## Test plan

- [x] `bundle exec rake project:lint` passes (436 files, 0 offenses).
- [x] `bundle exec rake project:tests` passes (636 examples, 0 failures, 2 pending pre-existing).
- [x] `bundle exec rake project:system-tests` passes (78 examples, 0 failures).
- [x] All overcommit hooks pass.
- [x] **MCP smoke tests against `https://catalyst.workeverywhere.docker/mcp`:**
  - No header → `-32001` with *"Missing X-Agent-Identifier header…"*.
  - `X-Agent-Identifier: jack` → 12 tools returned.
  - `X-Agent-Identifier: ghost` → `-32001` with the slug echoed back.
  - `X-Agent-Identifier: maree` + `initialize` → *"You are Marée, an AI travel assistant…"*.
- [x] End-to-end: `create_journal_entry` with `X-Agent-Identifier: maree` → DB `author` is `Marée <maree@system.local>`.
- [x] Home page renders cleanly (`tmp/phase19/01_home.png`).

## Deployment note

Phase 1 makes `X-Agent-Identifier` **required**. Coordinate merge + Kamal deploy with updating Claude Desktop configs for every agent machine — add `"X-Agent-Identifier": "jack"` (or `"maree"`) to the `headers` block alongside the existing Bearer token. After deploy, the first request from an un-updated config will return `-32001` with the message explaining what's needed.

Closes #116