### PR TITLE
Phase 20 — Complete MCP Server (content curation tools)

### DIFF
--- a/.claude/skills/trip-journal-mcp/SKILL.md
+++ b/.claude/skills/trip-journal-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trip-journal-mcp
-description: Connect to and operate the Trip Journal MCP server as Jack, the AI travel assistant. Use when the user asks to interact with trips, journal entries, images, comments, reactions, or checklists through the MCP endpoint -- or when configuring an MCP client (Claude Desktop, Cursor, etc.) to connect to this service. Covers all 12 tools, authentication, input validation, trip state constraints, and common workflows.
+description: Connect to and operate the Trip Journal MCP server as Jack, the AI travel assistant. Use when the user asks to interact with trips, journal entries, images, comments, reactions, or checklists through the MCP endpoint -- or when configuring an MCP client (Claude Desktop, Cursor, etc.) to connect to this service. Covers all 23 tools, authentication, input validation, trip state constraints, and common workflows.
 compatibility: Requires a running Trip Journal instance with MCP_API_KEY configured
 metadata:
   author: joel
@@ -53,7 +53,9 @@ Two layers:
 |------|-------------|----------|----------|
 | `create_journal_entry` | Create a journal entry | `name`, `entry_date` | `trip_id`, `body`, `location_name`, `description`, `telegram_message_id` |
 | `update_journal_entry` | Update an existing entry | `journal_entry_id` + at least one field | `name`, `body`, `entry_date`, `location_name`, `description` |
+| `delete_journal_entry` | Delete an entry (writable trips only) | `journal_entry_id` | (none) |
 | `list_journal_entries` | List entries with pagination | (none) | `trip_id`, `limit` (1-100, default 10), `offset` (>= 0) |
+| `get_journal_entry` | Get one entry: HTML body, counts, image URLs | `journal_entry_id` | (none) |
 
 ### Images
 
@@ -74,7 +76,11 @@ Both tools emit the same `journal_entry.images_added` event and reuse the same d
 | Tool | Description | Required | Optional |
 |------|-------------|----------|----------|
 | `create_comment` | Add a comment to an entry | `journal_entry_id`, `body` | `telegram_message_id` |
+| `update_comment` | Edit a comment's body (writable trips only) | `comment_id`, `body` | (none) |
+| `delete_comment` | Delete a comment (writable trips only) | `comment_id` | (none) |
+| `list_comments` | List an entry's comments, paginated | `journal_entry_id` | `limit`, `offset` |
 | `add_reaction` | Toggle an emoji reaction | `journal_entry_id`, `emoji` | (none) |
+| `list_reactions` | List an entry's reactions with reacting user | `journal_entry_id` | (none) |
 
 ### Trip Management
 
@@ -83,12 +89,20 @@ Both tools emit the same `journal_entry.images_added` event and reuse the same d
 | `update_trip` | Update name or description | at least one of `name`, `description` | `trip_id` |
 | `transition_trip` | Change trip state | `new_state` | `trip_id` |
 | `get_trip_status` | Get status, dates, counts | (none) | `trip_id` |
+| `list_trips` | List all trips (any state, incl. archived) | (none) | `limit`, `offset` |
+
+> Trip **creation** and **member administration** are deliberately not
+> exposed via MCP — those remain human-only. Likewise exports.
 
 ### Checklists
 
 | Tool | Description | Required | Optional |
 |------|-------------|----------|----------|
 | `list_checklists` | List all checklists with sections/items | (none) | `trip_id` |
+| `create_checklist` | Create a checklist (writable trips only) | `name` | `trip_id`, `position` |
+| `update_checklist` | Rename / reposition (writable trips only) | `checklist_id` + a field | `name`, `position` |
+| `delete_checklist` | Delete a checklist + contents (writable only) | `checklist_id` | (none) |
+| `create_checklist_item` | Add item to a section (writable only) | `checklist_section_id`, `content` | `position` |
 | `toggle_checklist_item` | Toggle item completion | `checklist_item_id` | (none) |
 
 ## Trip Resolution
@@ -137,8 +151,10 @@ Tools enforce state constraints. Calling a tool on an incompatible trip state re
 
 | Guard | Allowed states | Tools |
 |-------|---------------|-------|
-| `writable` | planning, started | create/update journal entry, add/upload images, update trip, toggle checklist |
+| `writable` | planning, started | create/update/delete journal entry, add/upload images, update trip, toggle checklist, update/delete comment, create/update/delete checklist, create checklist item |
 | `commentable` | planning, started, finished | create comment, add reaction |
+
+Read-only tools (`get_journal_entry`, `list_comments`, `list_reactions`, `list_trips`) have no state guard.
 
 ## Idempotency
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ When a PR receives code review comments:
 3. **For actionable feedback:** Fix the code, commit, push, then reply explaining what was fixed and in which commit.
 4. **For incorrect feedback:** Reply with a clear technical explanation of why no action is needed.
 5. **For deferred feedback:** Reply acknowledging the concern and stating which phase or PR will address it.
-6. **Reply to every comment** using `gh api repos/joel/trip/pulls/comments/<ID>/replies -X POST -f body='...'`.
+6. **Reply to every comment** using `gh api repos/joel/trip/pulls/<PR>/comments/<ID>/replies -X POST -f body='...'`. The `<PR>` number is required — omitting it (`gh api repos/joel/trip/pulls/comments/<ID>/replies`) returns `HTTP 404: Not Found`.
 7. **Resolve every conversation** after replying using the GraphQL `resolveReviewThread` mutation.
 8. Never leave review comments unanswered or unresolved.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ When a PR receives code review comments:
 
 MCP requests carry two pieces of identity:
 
-1. **`MCP_API_KEY`** — shared Bearer token for the endpoint (channel auth). A valid key grants **unrestricted read/write access to all domain data** through the 12 registered MCP tools (journal entries, images, comments, reactions, trips, checklists). Missing/wrong key → HTTP 401.
+1. **`MCP_API_KEY`** — shared Bearer token for the endpoint (channel auth). A valid key grants **unrestricted read/write access to all domain data** through the 23 registered MCP tools (journal entries, images, comments, reactions, checklists, plus read access to trips). Trip creation and member administration are deliberately not exposed — those remain human-only. Missing/wrong key → HTTP 401.
 2. **`X-Agent-Identifier` header** — slug of a registered `Agent` record (e.g. `jack`, `maree`). Resolves to the agent's system User, which is used as the author/actor for all writes (journal entries, comments, reactions). Missing or unknown slug → JSON-RPC error `-32001` with a readable message (HTTP 200 so the client sees it in-band). Register agents via Rails console: `Agent.create!(slug: "...", name: "...", user: <system_user>)`.
 
 Each agent has its own `@system.local` User. Subscription filters (`JournalEntries::Create#subscribe_trip_members`) exclude system actors from auto-subscription, so agents don't email themselves.

--- a/app/mcp/README.md
+++ b/app/mcp/README.md
@@ -27,7 +27,7 @@ The Model Context Protocol (MCP) server exposes trip journaling capabilities to 
        | require_writable!, require_commentable!
        | success_response / error_response
        v
-  12 MCP Tools  -->  Actions (Dry::Monads)  -->  ActiveRecord
+  23 MCP Tools  -->  Actions (Dry::Monads)  -->  ActiveRecord
 ```
 
 ## Endpoint
@@ -69,7 +69,9 @@ MCP_API_KEY=your-secret-key
 |------|-------------|-----------------|
 | `create_journal_entry` | Create a journal entry for a trip | `name`, `entry_date` |
 | `update_journal_entry` | Update an existing journal entry | `journal_entry_id` + at least one field |
+| `delete_journal_entry` | Delete an entry (writable trips only) | `journal_entry_id` |
 | `list_journal_entries` | List entries with pagination (limit 1-100) | (none) |
+| `get_journal_entry` | Get one entry: HTML body, counts, image URLs | `journal_entry_id` |
 
 ### Images
 
@@ -85,7 +87,11 @@ Allowed types: jpeg, png, webp, gif. Max 20 images per entry. `add_journal_image
 | Tool | Description | Required Params |
 |------|-------------|-----------------|
 | `create_comment` | Add a comment to a journal entry | `journal_entry_id`, `body` |
+| `update_comment` | Edit a comment's body (writable trips only) | `comment_id`, `body` |
+| `delete_comment` | Delete a comment (writable trips only) | `comment_id` |
+| `list_comments` | List an entry's comments, paginated, with author email + name | `journal_entry_id` |
 | `add_reaction` | Toggle an emoji reaction on an entry | `journal_entry_id`, `emoji` |
+| `list_reactions` | List an entry's reactions with reacting user | `journal_entry_id` |
 
 ### Trip Management
 
@@ -94,13 +100,33 @@ Allowed types: jpeg, png, webp, gif. Max 20 images per entry. `add_journal_image
 | `update_trip` | Update a trip's name or description | at least one of `name`, `description` |
 | `transition_trip` | Transition a trip to a new state | `new_state` |
 | `get_trip_status` | Get status, dates, counts for a trip | (none) |
+| `list_trips` | List all trips (any state, incl. archived), paginated | (none) |
 
 ### Checklists
 
 | Tool | Description | Required Params |
 |------|-------------|-----------------|
 | `list_checklists` | List all checklists with sections/items | (none) |
+| `create_checklist` | Create a checklist on a trip (writable only) | `name` |
+| `update_checklist` | Rename / reposition a checklist (writable only) | `checklist_id` + at least one field |
+| `delete_checklist` | Delete a checklist + its sections/items (writable only) | `checklist_id` |
+| `create_checklist_item` | Add an item to an existing section (writable only) | `checklist_section_id`, `content` |
 | `toggle_checklist_item` | Toggle a checklist item's completion | `checklist_item_id` |
+
+### Scope boundary (deliberately human-only)
+
+The MCP surface is intentionally limited to **content curation**. The
+following are **not** exposed and remain human-only operations:
+
+- **Trip creation** — a human sets the context the agent works inside.
+- **Member administration** — `assign`/`remove`/`list` trip members.
+- **Invitations** — onboarding new people is a human concern.
+- **Exports** — `Export#user` is a human recipient; needs an explicit
+  permission decision.
+
+Also out of scope until the underlying domain actions exist: image
+removal/replacement, checklist-item update/delete, checklist-section
+CRUD, and hard trip deletion.
 
 ## Trip Resolution
 
@@ -152,6 +178,17 @@ app/mcp/
     get_trip_status.rb
     add_journal_images.rb
     upload_journal_images.rb
+    get_journal_entry.rb       # Phase 20
+    delete_journal_entry.rb    # Phase 20
+    update_comment.rb          # Phase 20
+    delete_comment.rb          # Phase 20
+    list_comments.rb           # Phase 20
+    list_reactions.rb          # Phase 20
+    list_trips.rb              # Phase 20
+    create_checklist.rb        # Phase 20
+    update_checklist.rb        # Phase 20
+    delete_checklist.rb        # Phase 20
+    create_checklist_item.rb   # Phase 20
 ```
 
 ## Testing

--- a/app/mcp/tools/create_checklist.rb
+++ b/app/mcp/tools/create_checklist.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Tools
+  class CreateChecklist < BaseTool
+    description "Create a new checklist on a trip"
+
+    input_schema(
+      properties: {
+        trip_id: {
+          type: "string",
+          description: "Trip UUID (optional if exactly one " \
+                       "trip is started)"
+        },
+        name: { type: "string", description: "Checklist name" },
+        position: {
+          type: "integer",
+          description: "Sort position (optional)"
+        }
+      },
+      required: %w[name]
+    )
+
+    def self.call(name:, trip_id: nil, position: nil,
+                  _server_context: {})
+      trip = resolve_trip(trip_id)
+      require_writable!(trip)
+
+      params = { name: name, position: position }.compact
+      result = Checklists::Create.new.call(params: params, trip: trip)
+
+      case result
+      in Dry::Monads::Success(checklist)
+        success_response(
+          id: checklist.id, name: checklist.name,
+          trip_id: checklist.trip_id, position: checklist.position
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    end
+  end
+end

--- a/app/mcp/tools/create_checklist_item.rb
+++ b/app/mcp/tools/create_checklist_item.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Tools
+  class CreateChecklistItem < BaseTool
+    description "Add a new item to an existing checklist section " \
+                "(only on writable trips)"
+
+    input_schema(
+      properties: {
+        checklist_section_id: {
+          type: "string", description: "Checklist section UUID"
+        },
+        content: {
+          type: "string", description: "Item text"
+        },
+        position: {
+          type: "integer", description: "Sort position (optional)"
+        }
+      },
+      required: %w[checklist_section_id content]
+    )
+
+    def self.call(checklist_section_id:, content:, position: nil,
+                  _server_context: {})
+      section = ChecklistSection.find(checklist_section_id)
+      require_writable!(section.checklist.trip)
+
+      params = { content: content, position: position }.compact
+      result = ChecklistItems::Create.new.call(
+        params: params, checklist_section: section
+      )
+
+      case result
+      in Dry::Monads::Success(item)
+        success_response(
+          id: item.id, content: item.content,
+          completed: item.completed,
+          checklist_section_id: section.id
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response(
+        "Checklist section not found: #{checklist_section_id}"
+      )
+    end
+  end
+end

--- a/app/mcp/tools/delete_checklist.rb
+++ b/app/mcp/tools/delete_checklist.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Tools
+  class DeleteChecklist < BaseTool
+    description "Delete a checklist and its sections/items " \
+                "(only on writable trips)"
+
+    input_schema(
+      properties: {
+        checklist_id: {
+          type: "string", description: "Checklist UUID"
+        }
+      },
+      required: %w[checklist_id]
+    )
+
+    def self.call(checklist_id:, _server_context: {})
+      checklist = Checklist.find(checklist_id)
+      require_writable!(checklist.trip)
+
+      result = Checklists::Delete.new.call(checklist: checklist)
+
+      case result
+      in Dry::Monads::Success()
+        success_response(deleted: true, id: checklist_id)
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Checklist not found: #{checklist_id}")
+    end
+  end
+end

--- a/app/mcp/tools/delete_comment.rb
+++ b/app/mcp/tools/delete_comment.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Tools
+  class DeleteComment < BaseTool
+    description "Delete a comment (only on writable trips)"
+
+    input_schema(
+      properties: {
+        comment_id: {
+          type: "string", description: "Comment UUID"
+        }
+      },
+      required: %w[comment_id]
+    )
+
+    def self.call(comment_id:, _server_context: {})
+      comment = Comment.find(comment_id)
+      require_writable!(comment.journal_entry.trip)
+
+      result = Comments::Delete.new.call(comment: comment)
+
+      case result
+      in Dry::Monads::Success()
+        success_response(deleted: true, id: comment_id)
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Comment not found: #{comment_id}")
+    end
+  end
+end

--- a/app/mcp/tools/delete_comment.rb
+++ b/app/mcp/tools/delete_comment.rb
@@ -2,7 +2,7 @@
 
 module Tools
   class DeleteComment < BaseTool
-    description "Delete a comment (only on writable trips)"
+    description "Delete a comment (only on commentable trips)"
 
     input_schema(
       properties: {
@@ -15,7 +15,7 @@ module Tools
 
     def self.call(comment_id:, _server_context: {})
       comment = Comment.find(comment_id)
-      require_writable!(comment.journal_entry.trip)
+      require_commentable!(comment.journal_entry.trip)
 
       result = Comments::Delete.new.call(comment: comment)
 

--- a/app/mcp/tools/delete_journal_entry.rb
+++ b/app/mcp/tools/delete_journal_entry.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Tools
+  class DeleteJournalEntry < BaseTool
+    description "Delete a journal entry (only on writable trips)"
+
+    input_schema(
+      properties: {
+        journal_entry_id: {
+          type: "string",
+          description: "Journal entry UUID"
+        }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+      require_writable!(entry.trip)
+
+      result = JournalEntries::Delete.new.call(journal_entry: entry)
+
+      case result
+      in Dry::Monads::Success()
+        success_response(deleted: true, id: journal_entry_id)
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+  end
+end

--- a/app/mcp/tools/get_journal_entry.rb
+++ b/app/mcp/tools/get_journal_entry.rb
@@ -34,8 +34,18 @@ module Tools
 
     private_class_method def self.blob_url(blob)
       Rails.application.routes.url_helpers.rails_blob_url(
-        blob, host: ENV.fetch("APP_HOST", "localhost")
+        blob, **url_options
       )
+    end
+
+    # Derive the host/protocol from the per-environment Rails URL config
+    # (action_mailer.default_url_options) so external MCP clients receive
+    # reachable links. ENV["APP_HOST"] still overrides when set explicitly.
+    private_class_method def self.url_options
+      configured = Rails.application.config
+                        .action_mailer.default_url_options || {}
+      host = ENV["APP_HOST"].presence || configured[:host] || "localhost"
+      { host: host, protocol: configured[:protocol] }.compact
     end
   end
 end

--- a/app/mcp/tools/get_journal_entry.rb
+++ b/app/mcp/tools/get_journal_entry.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Tools
+  class GetJournalEntry < BaseTool
+    description "Get a single journal entry by ID with full body, " \
+                "image URLs, and counts"
+
+    input_schema(
+      properties: {
+        journal_entry_id: {
+          type: "string", description: "Journal entry UUID"
+        }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+
+      success_response(
+        id: entry.id, name: entry.name,
+        body: entry.body.to_s,
+        entry_date: entry.entry_date.to_s,
+        location_name: entry.location_name,
+        description: entry.description,
+        trip_id: entry.trip_id,
+        comments_count: entry.comments.count,
+        reactions_count: entry.reactions.count,
+        image_urls: entry.images.map { |img| blob_url(img) }
+      )
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+
+    private_class_method def self.blob_url(blob)
+      Rails.application.routes.url_helpers.rails_blob_url(
+        blob, host: ENV.fetch("APP_HOST", "localhost")
+      )
+    end
+  end
+end

--- a/app/mcp/tools/list_comments.rb
+++ b/app/mcp/tools/list_comments.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListComments < BaseTool
+    description "List comments on a journal entry with pagination"
+
+    input_schema(
+      properties: {
+        journal_entry_id: {
+          type: "string",
+          description: "Journal entry UUID"
+        },
+        limit: {
+          type: "integer",
+          description: "Max comments to return (default 10, max 100)"
+        },
+        offset: {
+          type: "integer",
+          description: "Number of comments to skip (default 0)"
+        }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, limit: 10, offset: 0,
+                  _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+      limit = limit.to_i.clamp(1, 100)
+      offset = [offset.to_i, 0].max
+
+      scope = entry.comments.chronological.includes(:user)
+
+      success_response(
+        comments: scope.offset(offset).limit(limit).map { |c| serialize(c) },
+        total: entry.comments.count, limit: limit, offset: offset
+      )
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+
+    private_class_method def self.serialize(comment)
+      {
+        id: comment.id, body: comment.body,
+        author_email: comment.user.email,
+        author_name: comment.user.name,
+        created_at: comment.created_at.iso8601
+      }
+    end
+  end
+end

--- a/app/mcp/tools/list_reactions.rb
+++ b/app/mcp/tools/list_reactions.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListReactions < BaseTool
+    description "List emoji reactions on a journal entry"
+
+    input_schema(
+      properties: {
+        journal_entry_id: {
+          type: "string",
+          description: "Journal entry UUID"
+        }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+      reactions = entry.reactions.includes(:user).order(created_at: :asc)
+
+      success_response(
+        reactions: reactions.map { |r| serialize(r) },
+        total: reactions.size
+      )
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+
+    private_class_method def self.serialize(reaction)
+      {
+        id: reaction.id, emoji: reaction.emoji,
+        user_email: reaction.user.email,
+        user_name: reaction.user.name
+      }
+    end
+  end
+end

--- a/app/mcp/tools/list_trips.rb
+++ b/app/mcp/tools/list_trips.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListTrips < BaseTool
+    description "List all trips (any state, including archived) " \
+                "with pagination"
+
+    input_schema(
+      properties: {
+        limit: {
+          type: "integer",
+          description: "Max trips to return (default 10, max 100)"
+        },
+        offset: {
+          type: "integer",
+          description: "Number of trips to skip (default 0)"
+        }
+      }
+    )
+
+    def self.call(limit: 10, offset: 0, _server_context: {})
+      limit = limit.to_i.clamp(1, 100)
+      offset = [offset.to_i, 0].max
+
+      trips = Trip.order(created_at: :desc).offset(offset).limit(limit).to_a
+      ids = trips.map(&:id)
+      members = TripMembership.where(trip_id: ids).group(:trip_id).count
+      entries = JournalEntry.where(trip_id: ids).group(:trip_id).count
+
+      success_response(
+        trips: trips.map { |trip| serialize(trip, members, entries) },
+        total: Trip.count, limit: limit, offset: offset
+      )
+    end
+
+    private_class_method def self.serialize(trip, members, entries)
+      {
+        id: trip.id, name: trip.name, state: trip.state,
+        start_date: trip.start_date&.to_s,
+        end_date: trip.end_date&.to_s,
+        member_count: members.fetch(trip.id, 0),
+        entry_count: entries.fetch(trip.id, 0)
+      }
+    end
+  end
+end

--- a/app/mcp/tools/update_checklist.rb
+++ b/app/mcp/tools/update_checklist.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateChecklist < BaseTool
+    description "Rename a checklist or change its sort position " \
+                "(only on writable trips)"
+
+    input_schema(
+      properties: {
+        checklist_id: {
+          type: "string", description: "Checklist UUID"
+        },
+        name: { type: "string", description: "New checklist name" },
+        position: {
+          type: "integer", description: "New sort position"
+        }
+      },
+      required: %w[checklist_id]
+    )
+
+    def self.call(checklist_id:, name: nil, position: nil,
+                  _server_context: {})
+      checklist = Checklist.find(checklist_id)
+      require_writable!(checklist.trip)
+
+      params = { name: name, position: position }.compact
+      raise ToolError, "No updatable parameters provided" if params.empty?
+
+      result = Checklists::Update.new.call(
+        checklist: checklist, params: params
+      )
+
+      case result
+      in Dry::Monads::Success(updated)
+        success_response(
+          id: updated.id, name: updated.name,
+          position: updated.position
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Checklist not found: #{checklist_id}")
+    end
+  end
+end

--- a/app/mcp/tools/update_comment.rb
+++ b/app/mcp/tools/update_comment.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateComment < BaseTool
+    description "Edit a comment's body (only on writable trips)"
+
+    input_schema(
+      properties: {
+        comment_id: {
+          type: "string", description: "Comment UUID"
+        },
+        body: {
+          type: "string", description: "New comment text"
+        }
+      },
+      required: %w[comment_id body]
+    )
+
+    def self.call(comment_id:, body:, _server_context: {})
+      comment = Comment.find(comment_id)
+      require_writable!(comment.journal_entry.trip)
+
+      params = { body: body }.compact
+      raise ToolError, "No updatable parameters provided" if params.empty?
+
+      result = Comments::Update.new.call(comment: comment, params: params)
+
+      case result
+      in Dry::Monads::Success(updated)
+        success_response(
+          id: updated.id, body: updated.body,
+          journal_entry_id: updated.journal_entry_id
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Comment not found: #{comment_id}")
+    end
+  end
+end

--- a/app/mcp/tools/update_comment.rb
+++ b/app/mcp/tools/update_comment.rb
@@ -2,7 +2,7 @@
 
 module Tools
   class UpdateComment < BaseTool
-    description "Edit a comment's body (only on writable trips)"
+    description "Edit a comment's body (only on commentable trips)"
 
     input_schema(
       properties: {
@@ -18,7 +18,7 @@ module Tools
 
     def self.call(comment_id:, body:, _server_context: {})
       comment = Comment.find(comment_id)
-      require_writable!(comment.journal_entry.trip)
+      require_commentable!(comment.journal_entry.trip)
 
       params = { body: body }.compact
       raise ToolError, "No updatable parameters provided" if params.empty?

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -23,7 +23,8 @@ class TripJournalServer
     Tools::DeleteComment,
     Tools::CreateChecklist,
     Tools::UpdateChecklist,
-    Tools::DeleteChecklist
+    Tools::DeleteChecklist,
+    Tools::CreateChecklistItem
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -17,7 +17,8 @@ class TripJournalServer
     Tools::GetJournalEntry,
     Tools::ListTrips,
     Tools::ListComments,
-    Tools::ListReactions
+    Tools::ListReactions,
+    Tools::DeleteJournalEntry
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -47,11 +47,15 @@ class TripJournalServer
       end
     <<~TEXT
       #{persona} for the Trip Journal app.
-      You can create and manage journal entries, attach images via URLs
-      or upload them directly as base64-encoded data, add comments and
-      reactions, update trip details, transition trip states, toggle
-      checklist items, and query trip status. When no trip_id is
-      provided, you operate on the single currently active (started) trip.
+      You can create, edit, and delete journal entries; attach images
+      via URLs or upload them directly as base64-encoded data; add and
+      remove emoji reactions; write, edit, and delete comments; create,
+      rename, and delete checklists and add items to them; update trip
+      details; transition trip states; and query trip status, entries,
+      comments, reactions, and the trip list. When no trip_id is
+      provided, you operate on the single currently active (started)
+      trip. Trip creation and member administration are handled by
+      humans.
     TEXT
   end
 end

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -22,7 +22,8 @@ class TripJournalServer
     Tools::UpdateComment,
     Tools::DeleteComment,
     Tools::CreateChecklist,
-    Tools::UpdateChecklist
+    Tools::UpdateChecklist,
+    Tools::DeleteChecklist
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -19,7 +19,8 @@ class TripJournalServer
     Tools::ListComments,
     Tools::ListReactions,
     Tools::DeleteJournalEntry,
-    Tools::UpdateComment
+    Tools::UpdateComment,
+    Tools::DeleteComment
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -16,7 +16,8 @@ class TripJournalServer
     Tools::UploadJournalImages,
     Tools::GetJournalEntry,
     Tools::ListTrips,
-    Tools::ListComments
+    Tools::ListComments,
+    Tools::ListReactions
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -15,7 +15,8 @@ class TripJournalServer
     Tools::AddJournalImages,
     Tools::UploadJournalImages,
     Tools::GetJournalEntry,
-    Tools::ListTrips
+    Tools::ListTrips,
+    Tools::ListComments
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -14,7 +14,8 @@ class TripJournalServer
     Tools::GetTripStatus,
     Tools::AddJournalImages,
     Tools::UploadJournalImages,
-    Tools::GetJournalEntry
+    Tools::GetJournalEntry,
+    Tools::ListTrips
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -20,7 +20,8 @@ class TripJournalServer
     Tools::ListReactions,
     Tools::DeleteJournalEntry,
     Tools::UpdateComment,
-    Tools::DeleteComment
+    Tools::DeleteComment,
+    Tools::CreateChecklist
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -13,7 +13,8 @@ class TripJournalServer
     Tools::ListChecklists,
     Tools::GetTripStatus,
     Tools::AddJournalImages,
-    Tools::UploadJournalImages
+    Tools::UploadJournalImages,
+    Tools::GetJournalEntry
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -18,7 +18,8 @@ class TripJournalServer
     Tools::ListTrips,
     Tools::ListComments,
     Tools::ListReactions,
-    Tools::DeleteJournalEntry
+    Tools::DeleteJournalEntry,
+    Tools::UpdateComment
   ].freeze
 
   def self.build(server_context: {})

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -21,7 +21,8 @@ class TripJournalServer
     Tools::DeleteJournalEntry,
     Tools::UpdateComment,
     Tools::DeleteComment,
-    Tools::CreateChecklist
+    Tools::CreateChecklist,
+    Tools::UpdateChecklist
   ].freeze
 
   def self.build(server_context: {})

--- a/docs/mcp-curl-cheatsheet.md
+++ b/docs/mcp-curl-cheatsheet.md
@@ -353,6 +353,139 @@ curl -s https://catalyst.workeverywhere.app/mcp \
   }'
 ```
 
+### Get Journal Entry
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"13","method":"tools/call",
+       "params":{"name":"get_journal_entry",
+       "arguments":{"journal_entry_id":"<uuid>"}}}'
+```
+
+### Delete Journal Entry
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"14","method":"tools/call",
+       "params":{"name":"delete_journal_entry",
+       "arguments":{"journal_entry_id":"<uuid>"}}}'
+```
+
+### List Trips
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"15","method":"tools/call",
+       "params":{"name":"list_trips",
+       "arguments":{"limit":10,"offset":0}}}'
+```
+
+### List Comments
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"16","method":"tools/call",
+       "params":{"name":"list_comments",
+       "arguments":{"journal_entry_id":"<uuid>"}}}'
+```
+
+### List Reactions
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"17","method":"tools/call",
+       "params":{"name":"list_reactions",
+       "arguments":{"journal_entry_id":"<uuid>"}}}'
+```
+
+### Update Comment
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"18","method":"tools/call",
+       "params":{"name":"update_comment",
+       "arguments":{"comment_id":"<uuid>","body":"Edited text"}}}'
+```
+
+### Delete Comment
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"19","method":"tools/call",
+       "params":{"name":"delete_comment",
+       "arguments":{"comment_id":"<uuid>"}}}'
+```
+
+### Create Checklist
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"20","method":"tools/call",
+       "params":{"name":"create_checklist",
+       "arguments":{"name":"Packing List"}}}'
+```
+
+### Update Checklist
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"21","method":"tools/call",
+       "params":{"name":"update_checklist",
+       "arguments":{"checklist_id":"<uuid>","name":"Renamed"}}}'
+```
+
+### Delete Checklist
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"22","method":"tools/call",
+       "params":{"name":"delete_checklist",
+       "arguments":{"checklist_id":"<uuid>"}}}'
+```
+
+### Create Checklist Item
+
+```bash
+curl -s https://catalyst.workeverywhere.app/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MCP_API_KEY" \
+  -H "X-Agent-Identifier: jack" \
+  -d '{"jsonrpc":"2.0","id":"23","method":"tools/call",
+       "params":{"name":"create_checklist_item",
+       "arguments":{"checklist_section_id":"<uuid>",
+       "content":"Passport"}}}'
+```
+
 ---
 
 ## Trip Resolution
@@ -363,8 +496,12 @@ When `trip_id` is omitted, the server auto-resolves to the single trip in `start
 
 | Guard | Allowed states | Tools |
 |-------|---------------|-------|
-| writable | planning, started | create/update entry, add/upload images, update trip, toggle checklist |
+| writable | planning, started | create/update/delete entry, add/upload images, update trip, toggle checklist, update/delete comment, create/update/delete checklist, create checklist item |
 | commentable | planning, started, finished | create comment, add reaction |
+
+Read-only tools (`get_journal_entry`, `list_*`) have no state guard.
+Trip creation, member administration, invitations, and exports are
+deliberately **not** exposed via MCP — they remain human-only.
 
 ## Quick Test
 

--- a/prompts/PROJECT SUMMARY.md
+++ b/prompts/PROJECT SUMMARY.md
@@ -28,7 +28,7 @@ Trip Journal is a **private, invite-only** collaborative trip journal. A small g
 | Uploads | **Active Storage** — disk dev; SeaweedFS planned for prod (#44) | |
 | Events | **Rails.event** structured subscribers | subscribers respond to `#emit(event)`, not `#call` |
 | Actions | **Dry::Monads** `Success`/`Failure` | see `app/actions/CLAUDE.md` for the pattern |
-| MCP | `mcp` gem at `POST /mcp`, 12 tools, API key via `MCP_API_KEY` | attributed to Jack |
+| MCP | `mcp` gem at `POST /mcp`, 23 tools, API key via `MCP_API_KEY` | attributed to the resolved agent |
 
 ---
 

--- a/prompts/Phase 20 - Steps.md
+++ b/prompts/Phase 20 - Steps.md
@@ -97,3 +97,44 @@ Per the user's call, fixed on a dedicated branch first:
   commit, but necessary to keep the suite green as tools were added
   (the growing `include(...)` list tripped `RSpec/ExampleLength`).
   `match_array` against a `let` is a stronger, self-maintaining check.
+
+### Post-tool fixes
+
+| – | `667598e` | _docs_ | README/cheatsheet/AGENTS/SUMMARY/SKILL + Steps |
+| – | `742051a` | _spec fix_ | `spec/requests/mcp_spec.rb` hard-coded the 12 original tool names (missed in plan §5 "no new request specs"); rewired to `match_array(TOOLS.map(&:name_value))` — self-maintaining |
+
+## 5. Validation
+
+- `bundle exec rubocop --parallel` → 458 files, 0 offenses (CI parity).
+- `bundle exec rake project:tests` → 681 examples, 0 failures, 2
+  pending (pre-existing helper stubs).
+- `bundle exec rake project:system-tests` → 79 examples, 0 failures.
+
+## 6. Runtime verification
+
+- `bin/cli app rebuild` + `restart` → `GET /up` 200. Mailcatcher
+  already running (11h uptime; `mail start` name-conflict is benign).
+- Live `tools/list` (`X-Agent-Identifier: jack`) → **23 tools**, all
+  11 new ones present.
+- `get_journal_entry` → returns HTML body (`<` present), comment/image
+  counts, image URLs.
+- `list_trips` → total 5, states `archived/cancelled/finished/
+  planning/started` (archived included, confirms Q5).
+- `create_checklist` (+ `position`) then `create_checklist_item` →
+  both succeed.
+- `update_comment` → body changed; `delete_comment` → `deleted:true`.
+- **State guard:** `delete_journal_entry` on an archived-trip entry →
+  `isError`, "Trip 'Patagonia Trek' is not writable (state:
+  archived)".
+- **Auth intact:** `X-Agent-Identifier: ghost` → JSON-RPC `-32001`.
+- **No stray email:** pre-flight audit proved the 6 new events have
+  no email subscriber (`NotificationSubscriber` filters to
+  `*.created` only); no mailer activity in app logs during the
+  write smoke tests. Mailcatcher HTTP API path differs in this build
+  (`/messages` 404) — relied on the audit + log inspection instead.
+- Smoke-test data (`Smoke CL` checklist, throwaway comment) cleaned up.
+
+## 7. Follow-up owed
+
+- Dedicated issue for the deferred `Rails/StrongParametersExpect`
+  migration across 14 controllers (from the #140 env fix).

--- a/prompts/Phase 20 - Steps.md
+++ b/prompts/Phase 20 - Steps.md
@@ -37,4 +37,41 @@ Verified that the 6 new events Phase 20 newly emits via the MCP surface do not t
 
 ## 4. Commits
 
-_To be appended as each commit lands._
+### Branch-setup commit
+
+- `ee4cc81` — Add Phase 20 plan + this Steps audit trail (`[skip ci]`).
+
+### Blocker: pre-existing env break (resolved out-of-band)
+
+While running commit 1's specs, `bundle exec` could not boot Rails:
+`LoadError: cannot load such file -- zip/zip`. Root cause: dependabot
+merged `rubyzip 3.3` (#129) to `main`, but `gepub 0.6.4.6` still uses
+the removed `require 'zip/zip'`. Two further dependabot bumps
+(rubocop 1.86.2 / rubocop-rails 2.35 / rubocop-capybara) activated CI
+cops the local `--lint`-only task never caught.
+
+Per the user's call, fixed on a dedicated branch first:
+
+- **Issue #139**, **PR #140** (`fix/gepub-rubyzip-3-compat`), merged to
+  `main` (commits `855c55a`, `85ca5fa`).
+  - `c97e880` — bump `gepub ~> 2.0` (uses `require 'zip'`, pins rubyzip
+    `>=3.0,<3.3`); rename stale `Capybara/NegationMatcherAfterVisit`
+    todo entry.
+  - `711c9d4` — autocorrect `have_content`→`have_text` (88) +
+    `Layout/MultilineMethodCallIndentation` (1); defer
+    `Rails/StrongParametersExpect` (30) to `.rubocop_todo.yml` with a
+    rationale (require→expect changes failure semantics; warrants its
+    own reviewed refactor).
+- **Follow-up owed:** dedicated issue for the `Rails/StrongParametersExpect`
+  migration across 14 controllers (deferred, not dropped).
+- Phase 20 branch rebased on the new `main`; commit-1 WIP restored from
+  stash; local validation now fully functional.
+
+### Tool commits
+
+| # | SHA | Tool | Notes |
+|---|-----|------|-------|
+| 1 | `a50c1ae` | `get_journal_entry` | HTML body via `body.to_s`; spec split to satisfy `RSpec/MultipleExpectations` |
+| 2 | `91fcdda` | `list_trips` | All states incl. archived; counts batched via grouped queries (Bullet-clean); uses raw `start_date`/`end_date` not effective (avoids per-row N+1) |
+| 3 | `4e46f18` | `list_comments` | Both `author_email` + `author_name`; `includes(:user)` |
+| 4 | `eaa019b` | `list_reactions` | Unpaginated (bounded); refactored server-spec registry assertion to `match_array` against a `let` (old `include` list tripped `RSpec/ExampleLength` as tools grew) |

--- a/prompts/Phase 20 - Steps.md
+++ b/prompts/Phase 20 - Steps.md
@@ -1,0 +1,40 @@
+# Phase 20 — Steps (audit trail)
+
+> Append-only log of decisions, commits, and verifications.
+> Plan: [`prompts/Phase 20 Complete MCP Server.md`](Phase%2020%20Complete%20MCP%20Server.md).
+
+---
+
+## 1. Issue + plan
+
+- **Issue:** [#138 — Phase 20 — Complete MCP Server (content curation tools)](https://github.com/joel/trip/issues/138) (label: `enhancement`).
+- **Plan:** `prompts/Phase 20 Complete MCP Server.md`.
+- **User approved the plan** after a question-and-answer round resolved §17 (HTML body, both author fields, hard pre-flight subscriber audit, 11 atomic commits, archived trips included, position allowed).
+
+## 1a. Kanban
+
+- **Blocked on scope:** `gh auth` keyring token is missing `read:project` / `write:project`. Same situation as Phase 19. Card transitions (Backlog → Ready → In Progress → In Review → Done) must be done manually, or after `gh auth refresh -s read:project,project`.
+
+## 2. Branch
+
+- `feature/phase20-complete-mcp-server` (off `main`).
+
+## 3. Pre-flight subscriber audit (§17 Q3 — hard gate)
+
+Verified that the 6 new events Phase 20 newly emits via the MCP surface do not trigger emails to `@system.local` users:
+
+| Event | Subscriber action | Verdict |
+|-------|--------------------|---------|
+| `journal_entry.deleted` | None — `JournalEntrySubscriber#emit` only handles `journal_entry.created` and `journal_entry.images_added` | Safe (event currently unconsumed) |
+| `comment.updated` | `CommentSubscriber` logs only | Safe |
+| `comment.deleted` | `CommentSubscriber` logs only | Safe |
+| `checklist.created` | `ChecklistSubscriber` logs only | Safe |
+| `checklist.updated` | `ChecklistSubscriber` logs only | Safe |
+| `checklist.deleted` | `ChecklistSubscriber` logs only | Safe |
+| `checklist_item.created` | `ChecklistSubscriber` logs only | Safe |
+
+`NotificationSubscriber` filter (`event_subscribers.rb:21-23`) restricts to `journal_entry.created` and `comment.created` — neither is a new event in Phase 20. No filters needed; proceeding to tool implementation.
+
+## 4. Commits
+
+_To be appended as each commit lands._

--- a/prompts/Phase 20 - Steps.md
+++ b/prompts/Phase 20 - Steps.md
@@ -75,3 +75,25 @@ Per the user's call, fixed on a dedicated branch first:
 | 2 | `91fcdda` | `list_trips` | All states incl. archived; counts batched via grouped queries (Bullet-clean); uses raw `start_date`/`end_date` not effective (avoids per-row N+1) |
 | 3 | `4e46f18` | `list_comments` | Both `author_email` + `author_name`; `includes(:user)` |
 | 4 | `eaa019b` | `list_reactions` | Unpaginated (bounded); refactored server-spec registry assertion to `match_array` against a `let` (old `include` list tripped `RSpec/ExampleLength` as tools grew) |
+| – | `bb0d40b` | _(Steps audit update — env-fix detour + reads 1-4; `[skip ci]`)_ |
+| 5 | `3437746` | `delete_journal_entry` | `require_writable!`; friendly RecordNotFound |
+| 6 | `eb6bc1e` | `update_comment` | Trip via `comment.journal_entry.trip`; body-only; blank body → validation Failure |
+| 7 | `824a34f` | `delete_comment` | `require_writable!` via entry's trip |
+| 8 | `817bb1b` | `create_checklist` | `require_writable!`; optional `position`; resolves started trip |
+| 9 | `d6a2fca` | `update_checklist` | `require_writable!`; empty-update rejected |
+| 10 | `e5a34fa` | `delete_checklist` | cascades sections/items via model `dependent: :destroy` |
+| 11 | `53d06e1` | `create_checklist_item` | `require_writable!` via `section.checklist.trip`; blank content → Failure |
+| 12 | `5a88100` | _server instructions_ | `instructions_for` advertises new verbs + human-only carve-out; new whitespace-normalised spec |
+
+### Deviations / notes for self-eval
+
+- **`[skip ci]` on `ee4cc81` and `bb0d40b`.** AGENTS.md §4 forbids
+  `[skip ci]` markers (CI uses `paths-ignore`; `prompts/**` is already
+  exempt). These two commits touched only `prompts/**` so there was no
+  functional impact, but the marker was unnecessary and against the
+  rule. Stopped using it from the docs commit onward. Recorded for the
+  skill self-eval.
+- **Tool-registry spec refactor bundled into commit 4.** Not its own
+  commit, but necessary to keep the suite green as tools were added
+  (the growing `include(...)` list tripped `RSpec/ExampleLength`).
+  `match_array` against a `let` is a stronger, self-maintaining check.

--- a/prompts/Phase 20 Complete MCP Server.md
+++ b/prompts/Phase 20 Complete MCP Server.md
@@ -1,0 +1,893 @@
+# PRP: Phase 20 — Complete MCP Server (Trip Administration Tools)
+
+**Status:** Draft (awaiting approval — do **not** start coding)
+**Date:** 2026-05-14
+**Type:** Feature (additive — new MCP tools only)
+**Confidence Score:** 9/10
+
+One-pass implementation confidence is high: every new tool wraps an existing `app/actions/**` operation with the same pattern as the 12 tools shipped in Phases 9–19. No new database table, no new auth surface, no new gem, no controller change. After trimming trip creation, member administration, and invitations, Phase 20 is a focused, mechanical addition of 11 tools.
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Goals and Non-Goals](#2-goals-and-non-goals)
+3. [Gap Analysis (Existing vs Missing)](#3-gap-analysis-existing-vs-missing)
+4. [Design Decisions To Confirm](#4-design-decisions-to-confirm)
+5. [Codebase Context](#5-codebase-context)
+6. [Tool Inventory (Phase 20)](#6-tool-inventory-phase-20)
+7. [Implementation Blueprint](#7-implementation-blueprint)
+8. [Task List (ordered)](#8-task-list-ordered)
+9. [Testing Strategy](#9-testing-strategy)
+10. [Validation Gates (Executable)](#10-validation-gates-executable)
+11. [Runtime Test Checklist](#11-runtime-test-checklist)
+12. [Documentation Updates](#12-documentation-updates)
+13. [Rollback Plan](#13-rollback-plan)
+14. [Future Work (Out of Scope)](#14-future-work-out-of-scope)
+15. [Reference Documentation](#15-reference-documentation)
+16. [Skill Self-Evaluation](#16-skill-self-evaluation)
+17. [Open Questions for the Operator](#17-open-questions-for-the-operator)
+
+---
+
+## 1. Problem Statement
+
+The MCP server (`app/mcp/trip_journal_server.rb`) currently exposes **12 tools**. A registered agent (Jack, Marée, …) can create journal entries, attach images, comment, react, update a trip, transition trip state, toggle checklist items, and read entries/checklists/status. Several content-curation operations that contributors can perform through the web UI are unreachable from the MCP surface.
+
+Concretely, an agent today **cannot**:
+
+- Delete a journal entry it created by mistake.
+- Edit or delete a comment.
+- Read a single journal entry's full body, or list its comments / reactions.
+- List the trips it should know about.
+- Create, rename, or delete a checklist.
+- Add a new item to an existing checklist section.
+
+The domain layer (`app/actions/**`) already implements 7 of these 11 missing operations. Phase 20 wraps them in `Tools::*` classes and registers them. The 4 read-only tools have no underlying action — they are thin Active Record reads, mirroring the shape of `list_journal_entries` / `get_trip_status`.
+
+Operations that touch **people** (creating trips, assigning/removing trip members, sending invitations) are intentionally **left to human operators**. Likewise `request_export` is deferred. See §14 for the rationale.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+1. Bring the MCP tool count from 12 → 23 by adding 11 new tools.
+2. Every new tool follows the existing `Tools::*` pattern: `BaseTool` subclass, `description`, `input_schema`, `self.call(..., server_context: {})`, `success_response` / `error_response`, `require_writable!` / `require_commentable!` guards where appropriate, `rescue ToolError` + `rescue ActiveRecord::RecordNotFound`.
+3. Every write tool that attributes a database write uses `resolve_agent_user(server_context)` — never hardcodes a user, never trusts a `user_id` parameter from the client.
+4. Every new tool has a spec file in `spec/mcp/tools/` mirroring the spec shape of the closest existing tool (happy path + not-found + state-guard + validation-failure where applicable).
+5. `app/mcp/README.md`, `docs/mcp-curl-cheatsheet.md`, `AGENTS.md`, `prompts/PROJECT SUMMARY.md`, and `.claude/skills/trip-journal-mcp/SKILL.md` reflect the new tool count and capabilities.
+6. `tools/list` returns 23 tools with valid input schemas; `bundle exec rake project:tests` and `project:system-tests` both pass.
+
+### Non-Goals (explicit — defer to future phases)
+
+- **Trip creation (`create_trip`).** Creating a trip is the human operator's responsibility — it sets the context the agent then works inside.
+- **Member administration (`assign_trip_member`, `remove_trip_member`, `list_trip_members`).** Adding/removing humans on a trip is a human concern; an agent should not be deciding who has access.
+- **Invitations (`send_invitation`).** Inviting a new person to the platform is member administration's entry point and stays with humans for consistency.
+- **`request_export`.** Deferred — `Export#user_id` semantics tie exports to a human recipient, and the permission model needs an operator decision.
+- **Image removal / replacement.** No `JournalEntries::DetachImage` action exists. Out of scope until that ships.
+- **Checklist item update / delete.** No `ChecklistItems::Update` / `Delete` actions exist. Toggling stays the only mutation.
+- **Checklist section CRUD.** No `app/actions/checklist_sections/` folder. `create_checklist_item` requires an existing `checklist_section_id`; section management is out of scope.
+- **Trip deletion.** No `Trips::Delete` action. Trips are deactivated via state transition (`archived` / `cancelled`).
+- **`accept_invitation`.** Recipient's flow, not an agent's.
+- **Access requests (`submit`, `approve`, `reject`).** Admin / public flows; not appropriate for an agent endpoint.
+- **Subscribe / unsubscribe a journal entry's notifications.** System actors are explicitly filtered out of subscription; having an agent subscribe itself would re-introduce the auto-notify-yourself bug Phase 15 QA flagged.
+- **ActionPolicy enforcement in tools.** Existing 12 tools intentionally bypass policy (channel auth + agent slug is the authorization surface for MCP). New tools mirror that. **Do not** add `authorize!` calls.
+- **Phase-2 per-trip pairing keys.** Phase 19 explicitly deferred those.
+
+---
+
+## 3. Gap Analysis (Existing vs Missing)
+
+Cross-reference between `app/actions/**` and `TripJournalServer::TOOLS` (current state, 2026-05-14):
+
+### Trips
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `Trips::Create` | ❌ | **DEFERRED** (human-only — see §2) |
+| `Trips::Update` | ✅ `update_trip` | — |
+| `Trips::TransitionState` | ✅ `transition_trip` | — |
+| (no list reader) | ❌ | **ADD** `list_trips` |
+
+### Journal Entries
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `JournalEntries::Create` | ✅ | — |
+| `JournalEntries::Update` | ✅ | — |
+| `JournalEntries::Delete` | ❌ | **ADD** `delete_journal_entry` |
+| `JournalEntries::AttachImages` | ✅ `add_journal_images` | — |
+| `JournalEntries::UploadImages` | ✅ `upload_journal_images` | — |
+| (no single-entry reader) | ❌ | **ADD** `get_journal_entry` |
+
+### Comments
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `Comments::Create` | ✅ | — |
+| `Comments::Update` | ❌ | **ADD** `update_comment` |
+| `Comments::Delete` | ❌ | **ADD** `delete_comment` |
+| (no list reader) | ❌ | **ADD** `list_comments` |
+
+### Reactions
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `Reactions::Toggle` | ✅ `add_reaction` | — |
+| (no list reader) | ❌ | **ADD** `list_reactions` |
+
+### Trip Memberships
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `TripMemberships::Assign` | ❌ | **DEFERRED** (human-only — see §2) |
+| `TripMemberships::Remove` | ❌ | **DEFERRED** (human-only) |
+| (no list reader) | ❌ | **DEFERRED** (human-only) |
+
+### Checklists
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `Checklists::Create` | ❌ | **ADD** `create_checklist` |
+| `Checklists::Update` | ❌ | **ADD** `update_checklist` |
+| `Checklists::Delete` | ❌ | **ADD** `delete_checklist` |
+| `list_checklists` | ✅ | — |
+
+### Checklist Items
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `ChecklistItems::Create` | ❌ | **ADD** `create_checklist_item` |
+| `ChecklistItems::Toggle` | ✅ `toggle_checklist_item` | — |
+
+### Invitations
+
+| Domain action | MCP tool? | Phase-20 action |
+|---|---|---|
+| `Invitations::SendInvitation` | ❌ | **DEFERRED** (human-only — see §2) |
+| `Invitations::Accept` | ❌ | **OUT** (recipient flow) |
+
+### Deferred (have actions but kept out — see §2)
+
+| Domain action | Reason for deferral |
+|---|---|
+| `Trips::Create` | Human operator sets the context the agent works in |
+| `TripMemberships::Assign / Remove` | People-management is a human concern |
+| `Invitations::SendInvitation` | Member administration's entry point — stays with humans |
+| `Exports::RequestExport` | `Export#user_id` semantics; needs operator decision |
+| `AccessRequests::Submit/Approve/Reject` | Admin flow; not an agent capability |
+
+### Deferred (no action exists yet — need new domain code first)
+
+- Remove / replace journal image
+- Update / delete checklist item
+- Checklist section CRUD
+- Trip delete
+
+---
+
+## 4. Design Decisions To Confirm
+
+These need the operator's sign-off **before** Step 1. Listed with my recommended default; if you accept the defaults the plan executes as-is.
+
+| # | Decision | Recommended | Rationale |
+|---|----------|-------------|-----------|
+| 1 | Tool count target | **11 new tools (23 total)** | Maps 1:1 onto §3 gap table after the human-only carve-out. |
+| 2 | Naming convention | Verb-object: `delete_journal_entry`, `update_comment`, etc. | Matches existing `create_journal_entry`, `update_trip`, `toggle_checklist_item`. |
+| 3 | State guards on writes | `delete_journal_entry`, `update_comment`, `delete_comment`, `create_checklist`, `update_checklist`, `delete_checklist`, `create_checklist_item` → **`require_writable!`** (planning/started only). | Matches existing pattern: archived/finished trips are read-only. |
+| 4 | Read tools — state guard | **None.** All states are listable. | Mirrors `list_journal_entries`, `list_checklists`. |
+| 5 | Pagination on list tools | All new `list_*` tools accept `limit` (1–100, default 10) + `offset` (≥0, default 0); return `{ items: [...], total:, limit:, offset: }`. `list_reactions` returns without pagination (bounded by `Reaction::ALLOWED_EMOJIS.size × member_count`). | Mirrors `list_journal_entries`. |
+| 6 | Authorization (policy enforcement) | **None.** Tools trust channel auth + agent identity. | Phase 19 established this; AGENTS.md MCP section codifies it. |
+| 7 | `delete_*` idempotency | If the record is already gone (`ActiveRecord::RecordNotFound`), return a friendly error rather than a success. | Matches existing behaviour for `update_journal_entry`. |
+| 8 | Commit grouping | **11 commits, one per tool** (+ 2 wrap-up commits for server instructions and docs). Each tool commit adds the tool file, its spec, registers it in `TOOLS`, and bumps the tool-count assertion in `trip_journal_server_spec.rb`. Reverting any single commit cleanly removes one tool with no broken test state. | Per operator preference for fine-grained revertability. |
+| 9 | Single PR or multiple? | **One PR.** All 11 tools are mechanically the same pattern. | Matches the way Phases 9–11 batched related MCP work. |
+
+**If any of the above are wrong, flag them in §17 Open Questions before approval.**
+
+---
+
+## 5. Codebase Context
+
+### Files to **read** (no edits — pattern reference)
+
+| File | What it shows |
+|------|---------------|
+| `app/mcp/tools/base_tool.rb` | Shared helpers: `success_response`, `error_response`, `resolve_trip`, `resolve_agent_user`, `require_writable!`, `require_commentable!`. **Do not modify in Phase 20.** |
+| `app/mcp/tools/update_trip.rb` | Canonical "update with optional fields" tool — copy for `update_comment`, `update_checklist`. |
+| `app/mcp/tools/toggle_checklist_item.rb` | Canonical "act on a single record by id" tool — copy for `delete_journal_entry`, `delete_comment`, `delete_checklist`. |
+| `app/mcp/tools/list_journal_entries.rb` | Canonical paginated read — copy for `list_trips`, `list_comments`. |
+| `app/mcp/tools/get_trip_status.rb` | Canonical single-record read — copy for `get_journal_entry`. |
+| `app/mcp/tools/create_journal_entry.rb` | Canonical write tool using `resolve_agent_user` — reference for `create_checklist`, `create_checklist_item`. |
+| `app/actions/CLAUDE.md` | Actions + Dry::Monads pattern; event names; pattern-matching. |
+| `spec/mcp/tools/create_comment_spec.rb` | Spec shape: `let(:agent) { create(:agent) }`, `let(:context) { { agent: agent } }`, then `described_class.call(..., server_context: context)`. |
+| `spec/mcp/tools/toggle_checklist_item_spec.rb` | Spec shape for state-guard + not-found assertions. |
+| `spec/factories/agents.rb`, `spec/factories/users.rb` (`:system_actor` trait) | Factories Phase 20 specs depend on. |
+
+### Files to **modify**
+
+| File | Why |
+|------|-----|
+| `app/mcp/trip_journal_server.rb` | Append 11 new tools to the `TOOLS` array. Update `instructions_for` to mention the new capabilities (deletion, comment edit/delete, checklist management). |
+| `app/mcp/tools/<new_tool>.rb` (×11) | New tool classes. |
+| `spec/mcp/tools/<new_tool>_spec.rb` (×11) | New tool specs. |
+| `spec/mcp/trip_journal_server_spec.rb` | Tool-count assertion 12 → 23. |
+| `app/mcp/README.md` | New rows in every domain section; update "12 Tools" prose. |
+| `docs/mcp-curl-cheatsheet.md` | New curl examples grouped by domain. |
+| `AGENTS.md` | The "12 registered MCP tools" line → 23. |
+| `prompts/PROJECT SUMMARY.md` | Line 31: "12 tools" → 23. |
+| `.claude/skills/trip-journal-mcp/SKILL.md` | Inventory section sync. |
+
+### Files to **create**
+
+11 new tool files + 11 new spec files (see §6 inventory).
+
+### Critical Gotchas
+
+1. **UUID primary keys.** All record IDs the tools receive are UUIDs as strings. Pass them straight to `Model.find`.
+
+2. **Don't `resolve_trip` for trip-derived operations.** Tools that operate on records that **already carry a trip** (a comment's journal entry's trip, a checklist's trip) derive the trip from the record, not from `trip_id`. Otherwise an agent could operate on Trip A's records while the "started trip" is Trip B and the writable check would target the wrong trip.
+
+   Correct (from `toggle_checklist_item.rb`):
+   ```ruby
+   item = ChecklistItem.find(checklist_item_id)
+   require_writable!(item.checklist_section.checklist.trip)
+   ```
+
+3. **`server_context` parameter naming.** Tools that **use** agent identity name the kwarg `server_context:` (un-underscored). Tools that don't use it name it `_server_context:`. In Phase 20, only `create_checklist`, `create_checklist_item` need un-underscored — they create records with attribution. The delete and update tools don't need the agent (the action signature doesn't take a user); use `_server_context:`. Same for all reads.
+
+4. **State guards apply *after* lookup, before mutation:**
+   ```ruby
+   record = Model.find(id)                # 1. lookup (may raise RecordNotFound)
+   require_writable!(record.trip)          # 2. guard (may raise ToolError)
+   result = Action.new.call(...)           # 3. mutate
+   ```
+
+5. **Rescue order:**
+   ```ruby
+   rescue ToolError => e
+     error_response(e.message)
+   rescue ActiveRecord::RecordNotFound
+     error_response("X not found: #{id}")
+   ```
+
+6. **Action signatures vary** — read each before writing the tool:
+   - `Comments::Update.new.call(comment:, params:)`
+   - `Comments::Delete.new.call(comment:)`
+   - `Checklists::Create.new.call(params:, trip:)`
+   - `Checklists::Update.new.call(checklist:, params:)`
+   - `Checklists::Delete.new.call(checklist:)`
+   - `ChecklistItems::Create.new.call(params:, checklist_section:)`
+   - `JournalEntries::Delete.new.call(journal_entry:)`
+
+7. **`Comments::Update`'s `params` whitelist is implicit.** `comment.update!(params)`, so the tool must filter — only `body` is sensibly updatable. Build `params = { body: body }.compact` and short-circuit if empty.
+
+8. **Tool count assertion in `spec/mcp/trip_journal_server_spec.rb`.** Currently likely `eq(12)` — bump to 23. Verify exact wording before editing.
+
+9. **MCP gem schema validation.** Use `enum: [...]` for constrained string fields; always provide `required:` even when empty.
+
+10. **Overcommit + schema hook.** No migrations in Phase 20, so `RailsSchemaUpToDate` is non-issue. RuboCop, whitespace, capitalised subjects apply normally.
+
+11. **Event subscriber check.** Phase 20 emits new events (`journal_entry.deleted`, `comment.updated`, `comment.deleted`, `checklist.created/updated/deleted`, `checklist_item.created`). Before merging, grep `config/initializers/event_subscribers.rb` + `app/subscribers/**` to confirm no subscriber emails the agent's own `@system.local` user when the actor is a system user. If any leaks, add a filter — see §17 Q3.
+
+---
+
+## 6. Tool Inventory (Phase 20)
+
+### Read-only tools (no agent attribution needed — `_server_context:`)
+
+| Tool | Input (required → optional) | Returns | Source |
+|------|------------------------------|---------|--------|
+| `get_journal_entry` | `journal_entry_id` | `{ id, name, body, entry_date, location_name, description, trip_id, comments_count, reactions_count, image_urls: [] }` | `JournalEntry.find` + assoc counts |
+| `list_trips` | — → `limit`, `offset` | `{ trips: [{ id, name, state, start_date, end_date, member_count, entry_count }], total, limit, offset }` paginated | `Trip.all.order(...)` |
+| `list_comments` | `journal_entry_id` → `limit`, `offset` | `{ comments: [{ id, body, author_email, author_name, created_at }], total, limit, offset }` | `entry.comments.chronological` |
+| `list_reactions` | `journal_entry_id` | `{ reactions: [{ id, emoji, user_email, user_name }], total }` (no pagination) | `entry.reactions.includes(:user)` |
+
+### Write tools
+
+| Tool | Input (required → optional) | Returns | Domain action | `server_context` |
+|------|------------------------------|---------|----------------|-------------------|
+| `delete_journal_entry` | `journal_entry_id` | `{ deleted: true, id }` | `JournalEntries::Delete` (with `require_writable!`) | `_server_context:` (no attribution) |
+| `update_comment` | `comment_id`, `body` | `{ id, body, journal_entry_id }` | `Comments::Update` (`require_writable!` on entry's trip) | `_server_context:` |
+| `delete_comment` | `comment_id` | `{ deleted: true, id }` | `Comments::Delete` (`require_writable!`) | `_server_context:` |
+| `create_checklist` | `name` → `trip_id`, `position` | `{ id, name, trip_id, position }` | `Checklists::Create` (`require_writable!`) | `_server_context:` (action doesn't take a user) |
+| `update_checklist` | `checklist_id`, `name` → `position` | `{ id, name, position }` | `Checklists::Update` (`require_writable!`) | `_server_context:` |
+| `delete_checklist` | `checklist_id` | `{ deleted: true, id }` | `Checklists::Delete` (`require_writable!`) | `_server_context:` |
+| `create_checklist_item` | `checklist_section_id`, `content` → `position` | `{ id, content, completed, checklist_section_id }` | `ChecklistItems::Create` (`require_writable!`) | `_server_context:` |
+
+**Total: 4 read tools + 7 write tools = 11 new tools.**
+
+Note: with the trim, *none* of the new Phase-20 write tools need `resolve_agent_user`. The domain actions for delete/update/create-checklist/create-checklist-item don't take a user kwarg — events are attributed by record ownership, not by an actor argument. This simplifies the implementation considerably.
+
+---
+
+## 7. Implementation Blueprint
+
+One representative tool per category is shown end-to-end. The remaining tools follow the same scaffolding — see §5 reference files.
+
+### 7.1 Read tool — `get_journal_entry.rb`
+
+```ruby
+# frozen_string_literal: true
+
+module Tools
+  class GetJournalEntry < BaseTool
+    description "Get a single journal entry by ID with full body, " \
+                "image URLs, and counts"
+
+    input_schema(
+      properties: {
+        journal_entry_id: {
+          type: "string", description: "Journal entry UUID"
+        }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+
+      success_response(
+        id: entry.id, name: entry.name,
+        body: entry.body.to_s,
+        entry_date: entry.entry_date.to_s,
+        location_name: entry.location_name,
+        description: entry.description,
+        trip_id: entry.trip_id,
+        comments_count: entry.comments.count,
+        reactions_count: entry.reactions.count,
+        image_urls: entry.images.map do |img|
+          Rails.application.routes.url_helpers
+               .rails_blob_url(img, host: ENV.fetch("APP_HOST", "localhost"))
+        end
+      )
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+  end
+end
+```
+
+**Notes:**
+- `body.to_s` returns the Action Text HTML (including embedded image references and formatting). Formatting matters to the operator, so HTML is preferred over `to_plain_text`.
+- Image URLs need a host. Read from `ENV["APP_HOST"]`.
+
+### 7.2 Paginated read tool — `list_comments.rb`
+
+```ruby
+# frozen_string_literal: true
+
+module Tools
+  class ListComments < BaseTool
+    description "List comments on a journal entry with pagination"
+
+    input_schema(
+      properties: {
+        journal_entry_id: { type: "string", description: "Journal entry UUID" },
+        limit:  { type: "integer", description: "Max comments (default 10, max 100)" },
+        offset: { type: "integer", description: "Skip count (default 0)" }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, limit: 10, offset: 0, _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+      limit = limit.to_i.clamp(1, 100)
+      offset = [offset.to_i, 0].max
+
+      scope = entry.comments.chronological.includes(:user)
+
+      success_response(
+        comments: scope.offset(offset).limit(limit).map { |c|
+          {
+            id: c.id, body: c.body,
+            author_email: c.user.email,
+            author_name: c.user.name,
+            created_at: c.created_at.iso8601
+          }
+        },
+        total: entry.comments.count, limit: limit, offset: offset
+      )
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+  end
+end
+```
+
+### 7.3 Single-record write — `delete_journal_entry.rb`
+
+```ruby
+# frozen_string_literal: true
+
+module Tools
+  class DeleteJournalEntry < BaseTool
+    description "Delete a journal entry (only on writable trips)"
+
+    input_schema(
+      properties: {
+        journal_entry_id: { type: "string", description: "Journal entry UUID" }
+      },
+      required: %w[journal_entry_id]
+    )
+
+    def self.call(journal_entry_id:, _server_context: {})
+      entry = JournalEntry.find(journal_entry_id)
+      require_writable!(entry.trip)
+
+      result = JournalEntries::Delete.new.call(journal_entry: entry)
+
+      case result
+      in Dry::Monads::Success()
+        success_response(deleted: true, id: journal_entry_id)
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Journal entry not found: #{journal_entry_id}")
+    end
+  end
+end
+```
+
+### 7.4 Update-with-fields — `update_comment.rb`
+
+```ruby
+# frozen_string_literal: true
+
+module Tools
+  class UpdateComment < BaseTool
+    description "Edit a comment's body (only on writable trips)"
+
+    input_schema(
+      properties: {
+        comment_id: { type: "string", description: "Comment UUID" },
+        body:       { type: "string", description: "New comment text" }
+      },
+      required: %w[comment_id body]
+    )
+
+    def self.call(comment_id:, body:, _server_context: {})
+      comment = Comment.find(comment_id)
+      require_writable!(comment.journal_entry.trip)
+
+      params = { body: body }.compact
+      raise ToolError, "No updatable parameters provided" if params.empty?
+
+      result = Comments::Update.new.call(comment: comment, params: params)
+
+      case result
+      in Dry::Monads::Success(updated)
+        success_response(
+          id: updated.id, body: updated.body,
+          journal_entry_id: updated.journal_entry_id
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Comment not found: #{comment_id}")
+    end
+  end
+end
+```
+
+### 7.5 Trip-scoped create — `create_checklist.rb`
+
+```ruby
+# frozen_string_literal: true
+
+module Tools
+  class CreateChecklist < BaseTool
+    description "Create a new checklist on a trip"
+
+    input_schema(
+      properties: {
+        trip_id:  { type: "string",
+                    description: "Trip UUID (optional if exactly one trip is started)" },
+        name:     { type: "string", description: "Checklist name" },
+        position: { type: "integer", description: "Sort position (optional)" }
+      },
+      required: %w[name]
+    )
+
+    def self.call(name:, trip_id: nil, position: nil, _server_context: {})
+      trip = resolve_trip(trip_id)
+      require_writable!(trip)
+
+      params = { name: name, position: position }.compact
+      result = Checklists::Create.new.call(params: params, trip: trip)
+
+      case result
+      in Dry::Monads::Success(checklist)
+        success_response(
+          id: checklist.id, name: checklist.name,
+          trip_id: checklist.trip_id, position: checklist.position
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    end
+  end
+end
+```
+
+### 7.6 Section-scoped create — `create_checklist_item.rb`
+
+```ruby
+# frozen_string_literal: true
+
+module Tools
+  class CreateChecklistItem < BaseTool
+    description "Add a new item to an existing checklist section"
+
+    input_schema(
+      properties: {
+        checklist_section_id: { type: "string", description: "Checklist section UUID" },
+        content:              { type: "string", description: "Item text" },
+        position:             { type: "integer", description: "Sort position (optional)" }
+      },
+      required: %w[checklist_section_id content]
+    )
+
+    def self.call(checklist_section_id:, content:, position: nil, _server_context: {})
+      section = ChecklistSection.find(checklist_section_id)
+      require_writable!(section.checklist.trip)
+
+      params = { content: content, position: position }.compact
+      result = ChecklistItems::Create.new.call(
+        params: params, checklist_section: section
+      )
+
+      case result
+      in Dry::Monads::Success(item)
+        success_response(
+          id: item.id, content: item.content,
+          completed: item.completed, checklist_section_id: section.id
+        )
+      in Dry::Monads::Failure(errors)
+        error_response(errors)
+      end
+    rescue ToolError => e
+      error_response(e.message)
+    rescue ActiveRecord::RecordNotFound
+      error_response("Checklist section not found: #{checklist_section_id}")
+    end
+  end
+end
+```
+
+### 7.7 Registration
+
+```ruby
+# app/mcp/trip_journal_server.rb (end state — TOOLS array)
+TOOLS = [
+  # Existing 12
+  Tools::CreateJournalEntry, Tools::UpdateJournalEntry,
+  Tools::ListJournalEntries, Tools::CreateComment,
+  Tools::AddReaction, Tools::UpdateTrip, Tools::TransitionTrip,
+  Tools::ToggleChecklistItem, Tools::ListChecklists,
+  Tools::GetTripStatus, Tools::AddJournalImages,
+  Tools::UploadJournalImages,
+  # Phase 20 — Reads
+  Tools::GetJournalEntry, Tools::ListTrips,
+  Tools::ListComments, Tools::ListReactions,
+  # Phase 20 — Writes
+  Tools::DeleteJournalEntry,
+  Tools::UpdateComment, Tools::DeleteComment,
+  Tools::CreateChecklist, Tools::UpdateChecklist,
+  Tools::DeleteChecklist, Tools::CreateChecklistItem
+].freeze
+```
+
+### 7.8 Updated `instructions_for(agent)`
+
+```ruby
+def self.instructions_for(agent)
+  persona =
+    if agent
+      "You are #{agent.name}, an AI travel assistant"
+    else
+      "You are an AI travel assistant"
+    end
+  <<~TEXT
+    #{persona} for the Trip Journal app.
+    You can create, edit, and delete journal entries; attach images
+    via URLs or upload them directly; add and remove emoji reactions;
+    write, edit, and delete comments; create, rename, and delete
+    checklists and add items to them; update trip details; transition
+    trip states; and query trip status. When no trip_id is provided,
+    you operate on the single currently active (started) trip. Trip
+    creation and member administration are handled by humans.
+  TEXT
+end
+```
+
+---
+
+## 8. Task List (ordered)
+
+Execute top-to-bottom. Eleven atomic tool commits + 2 wrap-up commits. Each tool commit is independently revertable: tool file + spec + `TOOLS` registration + tool-count assertion bump (`12 → 13 → … → 23`) all land together, so reverting that single commit cleanly removes one tool with no broken tests.
+
+### Pre-flight
+
+0. **Read** `AGENTS.md`, `app/actions/CLAUDE.md`, `app/mcp/README.md`, and this PRP end-to-end.
+1. **Confirm §4 decisions** and **§17 Open Questions are answered**.
+2. **Open GitHub issue** titled "Phase 20 — Complete MCP Server (Content Curation)". Label `feature`. Move **Backlog → Ready → In Progress** on the Trip Kanban Board.
+3. Create branch `feature/phase20-complete-mcp-server` off `main`.
+4. **Subscriber audit (hard pre-flight gate — operator-confirmed):** grep `config/initializers/event_subscribers.rb` + `app/subscribers/**` for handlers on `comment.updated`, `comment.deleted`, `journal_entry.deleted`, `checklist.created/updated/deleted`, `checklist_item.created`. Confirm none email `@system.local` users. If any leak, fix the filter (or file a sub-issue and add to §14) **before** writing tool code. Do not proceed to commit 1 until this is clean.
+
+### Per-commit recipe (applies to commits 1–11)
+
+For each tool in the order below:
+
+1. Create `app/mcp/tools/<tool>.rb` from the blueprint in §7 or the closest sibling tool.
+2. Create `spec/mcp/tools/<tool>_spec.rb` covering: happy path, not-found, state-guard (if applicable), validation failure (if applicable).
+3. Append the tool to `TripJournalServer::TOOLS` (preserve the §7.7 grouping comments — Reads block, Writes block).
+4. Bump the tool-count assertion in `spec/mcp/trip_journal_server_spec.rb` by one.
+5. Run `bundle exec rspec spec/mcp/` — green.
+6. Run `bundle exec rake project:fix-lint` then `project:lint` on the changed files — clean.
+7. Commit with the subject below; body explains *why* and lists the tool's purpose in one line.
+
+### Tool commits (11)
+
+| # | Tool | Commit subject | Section |
+|---|------|----------------|---------|
+| 1  | `get_journal_entry`     | `Add get_journal_entry MCP tool`     | §7.1 |
+| 2  | `list_trips`            | `Add list_trips MCP tool`            | §6 inventory |
+| 3  | `list_comments`         | `Add list_comments MCP tool`         | §7.2 |
+| 4  | `list_reactions`        | `Add list_reactions MCP tool`        | §6 inventory |
+| 5  | `delete_journal_entry`  | `Add delete_journal_entry MCP tool`  | §7.3 |
+| 6  | `update_comment`        | `Add update_comment MCP tool`        | §7.4 |
+| 7  | `delete_comment`        | `Add delete_comment MCP tool`        | §6 inventory |
+| 8  | `create_checklist`      | `Add create_checklist MCP tool`      | §7.5 |
+| 9  | `update_checklist`      | `Add update_checklist MCP tool`      | §6 inventory |
+| 10 | `delete_checklist`      | `Add delete_checklist MCP tool`      | §6 inventory |
+| 11 | `create_checklist_item` | `Add create_checklist_item MCP tool` | §7.6 |
+
+After commit 11, the tool-count assertion in `trip_journal_server_spec.rb` reads `eq(23)`.
+
+### Commit 12 — Server instructions refresh
+
+a. Update `TripJournalServer.instructions_for` per §7.8 — mentions delete/edit capabilities and the "trip creation and member administration are handled by humans" disclaimer.
+b. Update the existing instructions-text assertion in `spec/mcp/trip_journal_server_spec.rb` to match the new wording.
+c. Run `bundle exec rspec spec/mcp/` — green.
+d. Commit: **"Refresh MCP server instructions for Phase 20 capabilities"**.
+
+### Commit 13 — Documentation
+
+a. Update `app/mcp/README.md` — add rows in every section; replace "12 Tools" prose with "23 Tools"; note human-only carve-outs (trip creation, members, invitations) in a brief boundary section.
+b. Update `docs/mcp-curl-cheatsheet.md` — one curl example per new tool, grouped by section, with the Phase-19 `X-Agent-Identifier` header.
+c. Update `AGENTS.md` "12 registered MCP tools" → 23.
+d. Update `prompts/PROJECT SUMMARY.md` line 31 — "23 tools".
+e. Update `.claude/skills/trip-journal-mcp/SKILL.md` references.
+f. Commit: **"Document Phase 20 MCP tools"**.
+
+### Validate + ship
+
+12. Run `bundle exec rake project:fix-lint` → `project:lint` across the full tree — clean.
+13. Run `bundle exec rake project:tests` — full suite green.
+14. Run `bundle exec rake project:system-tests` — full suite green.
+15. Run §11 Runtime Test Checklist.
+16. Push branch.
+17. Open PR titled **"Phase 20 — Complete MCP Server"**, link the issue, summarise the 11 new tools + scope-out list. Move issue to **In Review**.
+18. Respond to every review comment per `AGENTS.md` §4. Resolve threads.
+19. After merge: move issue to **Done**. Smoke-test `tools/list` against production to confirm 23 tools listed.
+
+---
+
+## 9. Testing Strategy
+
+### Unit (per tool)
+
+For **every** new tool, the spec covers:
+
+1. **Happy path** — valid input returns a `success_response` whose JSON body has the documented fields.
+2. **Not-found** — invalid UUID returns `error_response("X not found: …")`.
+3. **State guard** — if the tool has `require_writable!`, archived/finished trip rejection.
+4. **Validation failure** — for write tools whose action can `Failure(errors)`, pass invalid input and assert the failure path.
+5. **Idempotency / edge case** — where applicable (e.g. `delete_journal_entry` called twice).
+6. **No-agent-attribution sanity check** — pass `_server_context: {}` and confirm the tool works (no Phase-20 write tool requires the agent).
+
+### Server
+
+- `spec/mcp/trip_journal_server_spec.rb`:
+  - Tool count = 23.
+  - Instructions text includes new capability keywords ("delete", "edit", "comments", "checklist") and the human-only disclaimer ("Trip creation and member administration are handled by humans").
+
+### Request (no new request specs needed)
+
+Existing `spec/requests/mcp_spec.rb` covers controller-level auth.
+
+### Integration (manual curl in §11)
+
+End-to-end through HTTP for at least one new tool from each category.
+
+### Out of scope
+
+- Browser UI tests (no UI surface added).
+- Performance / load (11 thin tools; same characteristics as existing 12).
+
+---
+
+## 10. Validation Gates (Executable)
+
+Per `AGENTS.md` §3:
+
+```bash
+bundle exec rake project:fix-lint
+bundle exec rake project:lint
+bundle exec rake project:tests
+bundle exec rake project:system-tests
+```
+
+All four green before pushing. Overcommit hooks (RuboCop, whitespace, capitalised subject, no trailing period, body width) run on every commit.
+
+---
+
+## 11. Runtime Test Checklist
+
+Per `AGENTS.md` §5 (mandatory before pushing):
+
+1. **Rebuild + restart:**
+   ```bash
+   bin/cli app rebuild
+   bin/cli app restart
+   bin/cli mail start
+   ```
+
+2. **MCP endpoint — `tools/list`:**
+   ```bash
+   curl -s https://catalyst.workeverywhere.docker/mcp \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer $MCP_API_KEY" \
+     -H "X-Agent-Identifier: jack" \
+     -d '{"jsonrpc":"2.0","id":"1","method":"tools/list"}' \
+     | python3 -m json.tool | grep '"name"' | wc -l
+   # expect: 23
+   ```
+
+3. **Per-domain smoke test:**
+
+   - Read: `list_trips`
+     ```bash
+     curl -s … -d '{"jsonrpc":"2.0","id":"2","method":"tools/call","params":{"name":"list_trips","arguments":{}}}'
+     ```
+   - Read: `get_journal_entry` for a seeded entry.
+   - Write: `delete_journal_entry` on a throwaway seeded entry, then verify it's gone:
+     ```bash
+     docker exec -i catalyst-app-dev bin/rails runner - <<'EOF'
+       puts JournalEntry.exists?("<uuid>") ? "still here" : "gone"
+     EOF
+     ```
+   - Write: `create_checklist` + `create_checklist_item` chained.
+   - Write: `update_comment` + `delete_comment` on a seeded comment.
+
+4. **State-guard smoke test** — archive a trip, attempt `delete_journal_entry` on one of its entries, confirm `error_response` with "not writable".
+
+5. **Browser sweep** against `https://catalyst.workeverywhere.docker/`:
+   - [ ] Home page renders (logged out + logged in).
+   - [ ] Sign-in works.
+   - [ ] Trip page reflects newly-created checklist.
+   - [ ] No runtime errors.
+
+6. **Mailcatcher sweep** — confirm no emails fire to `@system.local` users for any of the new tool invocations.
+
+---
+
+## 12. Documentation Updates
+
+| File | Change |
+|------|--------|
+| `app/mcp/README.md` | Add table rows for all 11 new tools; replace "12 Tools" prose with "23 Tools"; note human-only carve-outs (trip creation, member administration, invitations). |
+| `docs/mcp-curl-cheatsheet.md` | Add one curl example per new tool, grouped by section, with the Phase-19 `X-Agent-Identifier` header. |
+| `AGENTS.md` | Update count: "12 registered MCP tools" → 23. |
+| `prompts/PROJECT SUMMARY.md` | Line 31: "12 tools" → "23 tools". |
+| `.claude/skills/trip-journal-mcp/SKILL.md` | Update tool inventory section. |
+
+**Left alone:**
+- `docs/mcp-architecture.excalidraw` — adding 11 boxes isn't worth the time.
+- Historical `prompts/Phase N*.md` — append-only audit trail.
+
+---
+
+## 13. Rollback Plan
+
+Phase 20 is purely additive: new files, new entries in a frozen array, no schema changes.
+
+1. **Fast path (revert merge commit):** `git revert <merge sha>` and redeploy. No data implications.
+2. **Partial rollback:** Remove individual tools from `TripJournalServer::TOOLS` and redeploy. Tool files can remain on disk dormant.
+3. **No data rollback needed** — no migration to reverse.
+
+---
+
+## 14. Future Work (Out of Scope)
+
+Documented here so Phase 20 reviewers understand the deliberate boundary:
+
+1. **`create_trip` MCP tool.** Currently a human concern. If the operator later wants agents to scaffold trips, revisit — needs a decision on whether `created_by` is the agent's system user or a human owner.
+2. **Member administration (`assign_trip_member`, `remove_trip_member`, `list_trip_members`).** Human-only by design. Revisit if agent workflows ever need to read membership (note: `get_trip_status` already returns `member_count`, which may be enough).
+3. **`send_invitation`.** Same human-only boundary as #2.
+4. **`request_export` MCP tool.** Needs operator decision on `Export#user_id` semantics.
+5. **Image management.** Need new `JournalEntries::DetachImage` + `ReplaceImage` actions.
+6. **Checklist item update / delete.** Need new `ChecklistItems::Update` + `Delete` actions.
+7. **Checklist section CRUD.** New domain layer.
+8. **`Trips::Delete`.** Trips are state-machined, not destroyed. Add the action only if hard delete is genuinely needed.
+9. **Per-trip agent grants (Phase-19 Phase 2).** New tools will automatically respect the eventual grant table.
+10. **Admin UI for agent + trip-member management.** Web-side, not MCP-side.
+
+---
+
+## 15. Reference Documentation
+
+### In-repo
+
+- `app/mcp/README.md` — current MCP surface
+- `app/actions/CLAUDE.md` — action pattern + event names inventory
+- `AGENTS.md` — full governance + CLI + PR review rules
+- `prompts/Phase 19 - Agent Identity - Phase 1 - PRP.md` — agent identity model
+- `prompts/PROJECT SUMMARY.md` — stack overview
+
+### Existing tool exemplars
+
+- `app/mcp/tools/update_trip.rb`
+- `app/mcp/tools/toggle_checklist_item.rb`
+- `app/mcp/tools/list_journal_entries.rb`
+- `app/mcp/tools/create_journal_entry.rb`
+- `app/mcp/tools/get_trip_status.rb`
+
+### MCP / spec
+
+- MCP specification: <https://modelcontextprotocol.io/specification>
+- MCP Ruby SDK: <https://github.com/modelcontextprotocol/ruby-sdk>
+- JSON-RPC 2.0: <https://www.jsonrpc.org/specification>
+
+### Ruby / Rails
+
+- Rails 8.1 guides: <https://guides.rubyonrails.org/>
+- Active Record query interface: <https://guides.rubyonrails.org/active_record_querying.html>
+- Dry::Monads: <https://dry-rb.org/gems/dry-monads/>
+- RSpec-rails: <https://rspec.info/documentation/latest/rspec-rails/>
+- FactoryBot: <https://thoughtbot.github.io/factory_bot/>
+
+---
+
+## 16. Skill Self-Evaluation
+
+**Skill used:** `generate-prp`
+
+**Step audit:**
+- Codebase analysis covered all 12 existing tools and the underlying actions for the new ones.
+- External research was light; URLs were canonical from Phase 19.
+- I did **not** open `config/initializers/event_subscribers.rb` to verify §5 Gotcha 11 — queued instead as Step 4 of the task list and §17 Q3. Better answered with a grep at execution time than blocking the plan now.
+- Output target was overridden from `PRPs/<feature>.md` to `prompts/Phase 20 Complete MCP Server.md` per the user's explicit instruction.
+- After v1 scope discussion, dropped 5 tools (trip creation, member admin ×3, invitations) per user direction. Plan is now tighter and more confidently one-pass.
+
+**Improvement suggestion:** The `generate-prp` skill could prompt the author to explicitly mark which operations are **deliberately human-only** vs. **technically deferred** — this distinction matters for how the user thinks about future scope, and bare "out of scope" lists conflate the two. Phase 20's §2 / §14 now make that distinction; the skill template should encourage it for every PRP.
+
+---
+
+## 17. Open Questions for the Operator
+
+All questions resolved (operator answered 2026-05-14):
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | `get_journal_entry` body format | **HTML** (`body.to_s`) — formatting matters |
+| 2 | `list_comments` author field | **Keep both** `author_email` + `author_name` |
+| 3 | Subscriber audit timing | **Hard pre-flight gate** — §8 Step 4 must pass before any tool code is written |
+| 4 | Commit grouping | **11 atomic commits**, one per tool (+ 2 wrap-up) |
+| 5 | `list_trips` scope | **Include archived trips** — return all |
+| 6 | `position` parameter on checklist tools | **Allow** on create/update/create-item |
+
+---
+
+**STOP — plan complete. Awaiting operator approval before any code is written.**

--- a/spec/mcp/tools/create_checklist_item_spec.rb
+++ b/spec/mcp/tools/create_checklist_item_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::CreateChecklistItem do
+  describe ".call" do
+    it "adds an item to a section on a writable trip" do
+      trip = create(:trip, :started)
+      checklist = create(:checklist, trip: trip)
+      section = create(:checklist_section, checklist: checklist)
+
+      result = described_class.call(
+        checklist_section_id: section.id,
+        content: "Passport", position: 1
+      )
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["content"]).to eq("Passport")
+      expect(data["completed"]).to be(false)
+      expect(data["checklist_section_id"]).to eq(section.id)
+      expect(section.checklist_items.count).to eq(1)
+    end
+
+    it "rejects creation on a non-writable trip" do
+      trip = create(:trip, :archived)
+      checklist = create(:checklist, trip: trip)
+      section = create(:checklist_section, checklist: checklist)
+
+      result = described_class.call(
+        checklist_section_id: section.id, content: "Nope"
+      )
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+    end
+
+    it "returns a validation error for blank content" do
+      trip = create(:trip, :started)
+      section = create(:checklist_section,
+                       checklist: create(:checklist, trip: trip))
+
+      result = described_class.call(
+        checklist_section_id: section.id, content: ""
+      )
+
+      expect(result.error?).to be(true)
+    end
+
+    it "returns error for a nonexistent section" do
+      result = described_class.call(
+        checklist_section_id: "missing", content: "x"
+      )
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/create_checklist_spec.rb
+++ b/spec/mcp/tools/create_checklist_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::CreateChecklist do
+  describe ".call" do
+    it "creates a checklist on a writable trip" do
+      trip = create(:trip, :started)
+
+      result = described_class.call(
+        trip_id: trip.id, name: "Packing", position: 2
+      )
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["name"]).to eq("Packing")
+      expect(data["trip_id"]).to eq(trip.id)
+      expect(data["position"]).to eq(2)
+      expect(trip.checklists.count).to eq(1)
+    end
+
+    it "resolves the started trip when trip_id is omitted" do
+      create(:trip, :started)
+
+      result = described_class.call(name: "Default")
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["name"]).to eq("Default")
+    end
+
+    it "rejects creation on a non-writable trip" do
+      trip = create(:trip, :archived)
+
+      result = described_class.call(trip_id: trip.id, name: "Nope")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+    end
+
+    it "returns a validation error for a blank name" do
+      trip = create(:trip, :started)
+
+      result = described_class.call(trip_id: trip.id, name: "")
+
+      expect(result.error?).to be(true)
+    end
+  end
+end

--- a/spec/mcp/tools/delete_checklist_spec.rb
+++ b/spec/mcp/tools/delete_checklist_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::DeleteChecklist do
+  describe ".call" do
+    it "deletes a checklist on a writable trip" do
+      trip = create(:trip, :started)
+      checklist = create(:checklist, trip: trip)
+
+      result = described_class.call(checklist_id: checklist.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["deleted"]).to be(true)
+      expect(data["id"]).to eq(checklist.id)
+      expect(Checklist.exists?(checklist.id)).to be(false)
+    end
+
+    it "rejects deletion on a non-writable trip" do
+      trip = create(:trip, :archived)
+      checklist = create(:checklist, trip: trip)
+
+      result = described_class.call(checklist_id: checklist.id)
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+      expect(Checklist.exists?(checklist.id)).to be(true)
+    end
+
+    it "returns error for a nonexistent checklist" do
+      result = described_class.call(checklist_id: "missing")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/delete_comment_spec.rb
+++ b/spec/mcp/tools/delete_comment_spec.rb
@@ -17,7 +17,19 @@ RSpec.describe Tools::DeleteComment do
       expect(Comment.exists?(comment.id)).to be(false)
     end
 
-    it "rejects deletion on a non-writable trip" do
+    it "allows deletion on a finished (commentable) trip" do
+      trip = create(:trip, :finished)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry)
+
+      result = described_class.call(comment_id: comment.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["deleted"]).to be(true)
+      expect(Comment.exists?(comment.id)).to be(false)
+    end
+
+    it "rejects deletion on a non-commentable trip" do
       trip = create(:trip, :archived)
       entry = create(:journal_entry, trip: trip)
       comment = create(:comment, journal_entry: entry)
@@ -25,7 +37,7 @@ RSpec.describe Tools::DeleteComment do
       result = described_class.call(comment_id: comment.id)
 
       expect(result.error?).to be(true)
-      expect(result.content.first[:text]).to include("not writable")
+      expect(result.content.first[:text]).to include("not commentable")
       expect(Comment.exists?(comment.id)).to be(true)
     end
 

--- a/spec/mcp/tools/delete_comment_spec.rb
+++ b/spec/mcp/tools/delete_comment_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::DeleteComment do
+  describe ".call" do
+    it "deletes a comment on a writable trip" do
+      trip = create(:trip, :started)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry)
+
+      result = described_class.call(comment_id: comment.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["deleted"]).to be(true)
+      expect(data["id"]).to eq(comment.id)
+      expect(Comment.exists?(comment.id)).to be(false)
+    end
+
+    it "rejects deletion on a non-writable trip" do
+      trip = create(:trip, :archived)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry)
+
+      result = described_class.call(comment_id: comment.id)
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+      expect(Comment.exists?(comment.id)).to be(true)
+    end
+
+    it "returns error for a nonexistent comment" do
+      result = described_class.call(comment_id: "missing")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/delete_journal_entry_spec.rb
+++ b/spec/mcp/tools/delete_journal_entry_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::DeleteJournalEntry do
+  describe ".call" do
+    it "deletes an entry on a writable trip" do
+      trip = create(:trip, :started)
+      entry = create(:journal_entry, trip: trip)
+
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["deleted"]).to be(true)
+      expect(data["id"]).to eq(entry.id)
+      expect(JournalEntry.exists?(entry.id)).to be(false)
+    end
+
+    it "rejects deletion on a non-writable trip" do
+      trip = create(:trip, :archived)
+      entry = create(:journal_entry, trip: trip)
+
+      result = described_class.call(journal_entry_id: entry.id)
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+      expect(JournalEntry.exists?(entry.id)).to be(true)
+    end
+
+    it "returns error for a nonexistent entry" do
+      result = described_class.call(journal_entry_id: "missing")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/get_journal_entry_spec.rb
+++ b/spec/mcp/tools/get_journal_entry_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::GetJournalEntry do
+  let(:trip) { create(:trip, :started) }
+  let(:entry) do
+    create(:journal_entry, :with_location, trip: trip,
+                                           name: "Day 1",
+                                           description: "Arrival")
+  end
+
+  describe ".call" do
+    it "returns the entry core fields with HTML body" do
+      entry.body = "Hello <strong>world</strong>"
+      entry.save!
+
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["id"]).to eq(entry.id)
+      expect(data["name"]).to eq("Day 1")
+      expect(data["body"]).to include("<strong>world</strong>")
+      expect(data["location_name"]).to eq("Paris, France")
+      expect(data["description"]).to eq("Arrival")
+      expect(data["trip_id"]).to eq(trip.id)
+    end
+
+    it "returns zero counts and no images for a bare entry" do
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["comments_count"]).to eq(0)
+      expect(data["reactions_count"]).to eq(0)
+      expect(data["image_urls"]).to eq([])
+    end
+
+    it "counts comments and reactions" do
+      create(:comment, journal_entry: entry)
+      create(:reaction, reactable: entry)
+
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["comments_count"]).to eq(1)
+      expect(data["reactions_count"]).to eq(1)
+    end
+
+    it "returns image URLs when images are attached" do
+      with_images = create(:journal_entry, :with_images, trip: trip)
+
+      result = described_class.call(journal_entry_id: with_images.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["image_urls"].size).to eq(1)
+      expect(data["image_urls"].first).to include("rails/active_storage")
+    end
+
+    it "returns error for nonexistent entry" do
+      result = described_class.call(journal_entry_id: "missing-id")
+
+      expect(result.error?).to be true
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/list_comments_spec.rb
+++ b/spec/mcp/tools/list_comments_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListComments do
+  let(:entry) { create(:journal_entry) }
+
+  describe ".call" do
+    it "lists comments chronologically with author email and name" do
+      author = create(:user, name: "Jane Doe", email: "jane@example.com")
+      create(:comment, journal_entry: entry, user: author,
+                       body: "First!")
+
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+      row = data["comments"].first
+
+      expect(row["body"]).to eq("First!")
+      expect(row["author_email"]).to eq("jane@example.com")
+      expect(row["author_name"]).to eq("Jane Doe")
+      expect(data["total"]).to eq(1)
+    end
+
+    it "paginates with clamped limit and offset" do
+      create_list(:comment, 3, journal_entry: entry)
+
+      result = described_class.call(
+        journal_entry_id: entry.id, limit: 1, offset: 1
+      )
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["comments"].size).to eq(1)
+      expect(data["limit"]).to eq(1)
+      expect(data["offset"]).to eq(1)
+      expect(data["total"]).to eq(3)
+    end
+
+    it "returns error for a nonexistent journal entry" do
+      result = described_class.call(journal_entry_id: "missing")
+
+      expect(result.error?).to be true
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/list_reactions_spec.rb
+++ b/spec/mcp/tools/list_reactions_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListReactions do
+  let(:entry) { create(:journal_entry) }
+
+  describe ".call" do
+    it "lists reactions with emoji and reacting user" do
+      reactor = create(:user, name: "Bob", email: "bob@example.com")
+      create(:reaction, reactable: entry, user: reactor,
+                        emoji: "heart")
+
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+      row = data["reactions"].first
+
+      expect(row["emoji"]).to eq("heart")
+      expect(row["user_email"]).to eq("bob@example.com")
+      expect(row["user_name"]).to eq("Bob")
+      expect(data["total"]).to eq(1)
+    end
+
+    it "returns an empty list when there are no reactions" do
+      result = described_class.call(journal_entry_id: entry.id)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["reactions"]).to eq([])
+      expect(data["total"]).to eq(0)
+    end
+
+    it "returns error for a nonexistent journal entry" do
+      result = described_class.call(journal_entry_id: "missing")
+
+      expect(result.error?).to be true
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/list_trips_spec.rb
+++ b/spec/mcp/tools/list_trips_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListTrips do
+  describe ".call" do
+    it "lists trips of any state, newest first" do
+      create(:trip, name: "Planning Trip")
+      create(:trip, :archived, name: "Old Trip")
+
+      result = described_class.call
+      data = JSON.parse(result.content.first[:text])
+
+      names = data["trips"].pluck("name")
+      expect(names).to contain_exactly("Planning Trip", "Old Trip")
+      expect(data["total"]).to eq(2)
+    end
+
+    it "includes archived trips" do
+      create(:trip, :archived, name: "Archived One")
+
+      result = described_class.call
+      data = JSON.parse(result.content.first[:text])
+
+      states = data["trips"].pluck("state")
+      expect(states).to include("archived")
+    end
+
+    it "returns member and entry counts" do
+      trip = create(:trip, :started)
+      create(:trip_membership, trip: trip)
+      create(:journal_entry, trip: trip)
+
+      result = described_class.call
+      data = JSON.parse(result.content.first[:text])
+      row = data["trips"].find { |t| t["id"] == trip.id }
+
+      expect(row["member_count"]).to eq(1)
+      expect(row["entry_count"]).to eq(1)
+    end
+
+    it "clamps limit and respects offset" do
+      create_list(:trip, 3)
+
+      result = described_class.call(limit: 1, offset: 1)
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["trips"].size).to eq(1)
+      expect(data["limit"]).to eq(1)
+      expect(data["offset"]).to eq(1)
+      expect(data["total"]).to eq(3)
+    end
+  end
+end

--- a/spec/mcp/tools/update_checklist_spec.rb
+++ b/spec/mcp/tools/update_checklist_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::UpdateChecklist do
+  describe ".call" do
+    it "renames a checklist on a writable trip" do
+      trip = create(:trip, :started)
+      checklist = create(:checklist, trip: trip, name: "Old")
+
+      result = described_class.call(
+        checklist_id: checklist.id, name: "New", position: 5
+      )
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["name"]).to eq("New")
+      expect(data["position"]).to eq(5)
+      expect(checklist.reload.name).to eq("New")
+    end
+
+    it "rejects updates on a non-writable trip" do
+      trip = create(:trip, :archived)
+      checklist = create(:checklist, trip: trip, name: "Old")
+
+      result = described_class.call(
+        checklist_id: checklist.id, name: "New"
+      )
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+      expect(checklist.reload.name).to eq("Old")
+    end
+
+    it "errors when no updatable params are given" do
+      checklist = create(:checklist, trip: create(:trip, :started))
+
+      result = described_class.call(checklist_id: checklist.id)
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text])
+        .to include("No updatable parameters")
+    end
+
+    it "returns error for a nonexistent checklist" do
+      result = described_class.call(checklist_id: "missing", name: "x")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/update_comment_spec.rb
+++ b/spec/mcp/tools/update_comment_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::UpdateComment do
+  describe ".call" do
+    it "updates the comment body on a writable trip" do
+      trip = create(:trip, :started)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry, body: "Old")
+
+      result = described_class.call(comment_id: comment.id, body: "New")
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["body"]).to eq("New")
+      expect(data["journal_entry_id"]).to eq(entry.id)
+      expect(comment.reload.body).to eq("New")
+    end
+
+    it "rejects edits on a non-writable trip" do
+      trip = create(:trip, :archived)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry, body: "Old")
+
+      result = described_class.call(comment_id: comment.id, body: "New")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not writable")
+      expect(comment.reload.body).to eq("Old")
+    end
+
+    it "returns a validation error for a blank body" do
+      comment = create(:comment)
+
+      result = described_class.call(comment_id: comment.id, body: "")
+
+      expect(result.error?).to be(true)
+    end
+
+    it "returns error for a nonexistent comment" do
+      result = described_class.call(comment_id: "missing", body: "x")
+
+      expect(result.error?).to be(true)
+      expect(result.content.first[:text]).to include("not found")
+    end
+  end
+end

--- a/spec/mcp/tools/update_comment_spec.rb
+++ b/spec/mcp/tools/update_comment_spec.rb
@@ -17,7 +17,19 @@ RSpec.describe Tools::UpdateComment do
       expect(comment.reload.body).to eq("New")
     end
 
-    it "rejects edits on a non-writable trip" do
+    it "allows edits on a finished (commentable) trip" do
+      trip = create(:trip, :finished)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry, body: "Old")
+
+      result = described_class.call(comment_id: comment.id, body: "New")
+      data = JSON.parse(result.content.first[:text])
+
+      expect(data["body"]).to eq("New")
+      expect(comment.reload.body).to eq("New")
+    end
+
+    it "rejects edits on a non-commentable trip" do
       trip = create(:trip, :archived)
       entry = create(:journal_entry, trip: trip)
       comment = create(:comment, journal_entry: entry, body: "Old")
@@ -25,7 +37,7 @@ RSpec.describe Tools::UpdateComment do
       result = described_class.call(comment_id: comment.id, body: "New")
 
       expect(result.error?).to be(true)
-      expect(result.content.first[:text]).to include("not writable")
+      expect(result.content.first[:text]).to include("not commentable")
       expect(comment.reload.body).to eq("Old")
     end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe TripJournalServer do
       Tools::UpdateComment,
       Tools::DeleteComment,
       Tools::CreateChecklist,
-      Tools::UpdateChecklist
+      Tools::UpdateChecklist,
+      Tools::DeleteChecklist
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 RSpec.describe TripJournalServer do
   describe ".build" do
-    it "creates an MCP server with all 14 tools" do
+    it "creates an MCP server with all 15 tools" do
       server = described_class.build
       expect(server).to be_a(MCP::Server)
     end
 
     it "registers all expected tools" do
-      expect(described_class::TOOLS.size).to eq(14)
+      expect(described_class::TOOLS.size).to eq(15)
       expect(described_class::TOOLS).to include(
         Tools::CreateJournalEntry,
         Tools::UpdateJournalEntry,
@@ -25,7 +25,8 @@ RSpec.describe TripJournalServer do
         Tools::AddJournalImages,
         Tools::UploadJournalImages,
         Tools::GetJournalEntry,
-        Tools::ListTrips
+        Tools::ListTrips,
+        Tools::ListComments
       )
     end
   end

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe TripJournalServer do
       Tools::ListComments,
       Tools::ListReactions,
       Tools::DeleteJournalEntry,
-      Tools::UpdateComment
+      Tools::UpdateComment,
+      Tools::DeleteComment
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 RSpec.describe TripJournalServer do
   describe ".build" do
-    it "creates an MCP server with all 13 tools" do
+    it "creates an MCP server with all 14 tools" do
       server = described_class.build
       expect(server).to be_a(MCP::Server)
     end
 
     it "registers all expected tools" do
-      expect(described_class::TOOLS.size).to eq(13)
+      expect(described_class::TOOLS.size).to eq(14)
       expect(described_class::TOOLS).to include(
         Tools::CreateJournalEntry,
         Tools::UpdateJournalEntry,
@@ -24,7 +24,8 @@ RSpec.describe TripJournalServer do
         Tools::GetTripStatus,
         Tools::AddJournalImages,
         Tools::UploadJournalImages,
-        Tools::GetJournalEntry
+        Tools::GetJournalEntry,
+        Tools::ListTrips
       )
     end
   end

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe TripJournalServer do
       Tools::DeleteJournalEntry,
       Tools::UpdateComment,
       Tools::DeleteComment,
-      Tools::CreateChecklist
+      Tools::CreateChecklist,
+      Tools::UpdateChecklist
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -3,31 +3,34 @@
 require "rails_helper"
 
 RSpec.describe TripJournalServer do
+  let(:expected_tools) do
+    [
+      Tools::CreateJournalEntry,
+      Tools::UpdateJournalEntry,
+      Tools::ListJournalEntries,
+      Tools::CreateComment,
+      Tools::AddReaction,
+      Tools::UpdateTrip,
+      Tools::TransitionTrip,
+      Tools::ToggleChecklistItem,
+      Tools::ListChecklists,
+      Tools::GetTripStatus,
+      Tools::AddJournalImages,
+      Tools::UploadJournalImages,
+      Tools::GetJournalEntry,
+      Tools::ListTrips,
+      Tools::ListComments,
+      Tools::ListReactions
+    ]
+  end
+
   describe ".build" do
-    it "creates an MCP server with all 15 tools" do
-      server = described_class.build
-      expect(server).to be_a(MCP::Server)
+    it "creates an MCP server" do
+      expect(described_class.build).to be_a(MCP::Server)
     end
 
-    it "registers all expected tools" do
-      expect(described_class::TOOLS.size).to eq(15)
-      expect(described_class::TOOLS).to include(
-        Tools::CreateJournalEntry,
-        Tools::UpdateJournalEntry,
-        Tools::ListJournalEntries,
-        Tools::CreateComment,
-        Tools::AddReaction,
-        Tools::UpdateTrip,
-        Tools::TransitionTrip,
-        Tools::ToggleChecklistItem,
-        Tools::ListChecklists,
-        Tools::GetTripStatus,
-        Tools::AddJournalImages,
-        Tools::UploadJournalImages,
-        Tools::GetJournalEntry,
-        Tools::ListTrips,
-        Tools::ListComments
-      )
+    it "registers exactly the expected tools" do
+      expect(described_class::TOOLS).to match_array(expected_tools)
     end
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe TripJournalServer do
       Tools::DeleteComment,
       Tools::CreateChecklist,
       Tools::UpdateChecklist,
-      Tools::DeleteChecklist
+      Tools::DeleteChecklist,
+      Tools::CreateChecklistItem
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe TripJournalServer do
       Tools::ListReactions,
       Tools::DeleteJournalEntry,
       Tools::UpdateComment,
-      Tools::DeleteComment
+      Tools::DeleteComment,
+      Tools::CreateChecklist
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe TripJournalServer do
       Tools::ListTrips,
       Tools::ListComments,
       Tools::ListReactions,
-      Tools::DeleteJournalEntry
+      Tools::DeleteJournalEntry,
+      Tools::UpdateComment
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 RSpec.describe TripJournalServer do
   describe ".build" do
-    it "creates an MCP server with all 12 tools" do
+    it "creates an MCP server with all 13 tools" do
       server = described_class.build
       expect(server).to be_a(MCP::Server)
     end
 
     it "registers all expected tools" do
-      expect(described_class::TOOLS.size).to eq(12)
+      expect(described_class::TOOLS.size).to eq(13)
       expect(described_class::TOOLS).to include(
         Tools::CreateJournalEntry,
         Tools::UpdateJournalEntry,
@@ -23,7 +23,8 @@ RSpec.describe TripJournalServer do
         Tools::ListChecklists,
         Tools::GetTripStatus,
         Tools::AddJournalImages,
-        Tools::UploadJournalImages
+        Tools::UploadJournalImages,
+        Tools::GetJournalEntry
       )
     end
   end

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe TripJournalServer do
       Tools::GetJournalEntry,
       Tools::ListTrips,
       Tools::ListComments,
-      Tools::ListReactions
+      Tools::ListReactions,
+      Tools::DeleteJournalEntry
     ]
   end
 

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -52,5 +52,16 @@ RSpec.describe TripJournalServer do
       expect(described_class.instructions_for(nil))
         .to include("You are an AI travel assistant")
     end
+
+    it "describes the Phase 20 capabilities and human-only carve-out" do
+      text = described_class.instructions_for(nil).gsub(/\s+/, " ")
+
+      expect(text).to include("create, edit, and delete journal entries")
+      expect(text).to include("delete comments")
+      expect(text).to include("delete checklists")
+      expect(text)
+        .to include("Trip creation and member administration are " \
+                    "handled by humans")
+    end
   end
 end

--- a/spec/requests/mcp_spec.rb
+++ b/spec/requests/mcp_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "MCP Endpoint" do
         expect(instructions).to include("You are Jack")
       end
 
-      it "lists all 12 tools" do
+      it "lists exactly the registered tools" do
         post "/mcp", params: init_payload, headers: headers
 
         list_payload = {
@@ -134,13 +134,14 @@ RSpec.describe "MCP Endpoint" do
 
         tool_names = response.parsed_body["result"]["tools"]
                              .pluck("name")
-        expect(tool_names).to contain_exactly(
-          "create_journal_entry", "update_journal_entry",
-          "list_journal_entries", "create_comment",
-          "add_reaction", "update_trip", "transition_trip",
-          "toggle_checklist_item", "list_checklists",
-          "get_trip_status", "add_journal_images",
-          "upload_journal_images"
+        expect(tool_names)
+          .to match_array(TripJournalServer::TOOLS.map(&:name_value))
+        expect(tool_names).to include(
+          "get_journal_entry", "delete_journal_entry",
+          "update_comment", "delete_comment", "list_comments",
+          "list_reactions", "list_trips", "create_checklist",
+          "update_checklist", "delete_checklist",
+          "create_checklist_item"
         )
       end
 


### PR DESCRIPTION
## Summary

Adds **11 new MCP tools** (4 read, 7 write), taking the registered set from 12 → **23**. Every tool wraps an existing `app/actions/**` operation (or a thin Active Record read) using the established `Tools::*` pattern — no new tables, no auth changes, no controller changes.

**Reads:** `get_journal_entry`, `list_trips`, `list_comments`, `list_reactions`
**Writes:** `delete_journal_entry`, `update_comment`, `delete_comment`, `create_checklist`, `update_checklist`, `delete_checklist`, `create_checklist_item`

**Deliberately human-only (out of scope):** trip creation, member administration, invitations, exports. Documented in `app/mcp/README.md`, `AGENTS.md`, the curl cheatsheet, and the `trip-journal-mcp` skill.

Plan: `prompts/Phase 20 Complete MCP Server.md` · Audit trail: `prompts/Phase 20 - Steps.md`

### Design notes

- 13 atomic commits — one per tool (each ships tool + spec + registration), plus server-instructions, docs, and a self-maintaining request-spec fix. Any single tool is independently revertable.
- All Phase 20 write tools use `_server_context:` (no agent attribution needed — the delete/update/create actions don't take a user kwarg; events are attributed by record ownership).
- State guards: every write tool that mutates trip content uses `require_writable!` (derived from the record's own trip, never `resolve_trip`, to prevent cross-trip leakage).
- `list_trips` batches member/entry counts via grouped queries (Bullet-clean, no N+1).
- Server-spec tool registry refactored to `match_array` against a `let` so it never goes stale as the registry grows.

### Pre-flight subscriber audit (PRP §17 Q3)

Verified the 6 new events Phase 20 emits (`journal_entry.deleted`, `comment.updated/deleted`, `checklist.created/updated/deleted`, `checklist_item.created`) hit logging-only or unconsumed subscribers. `NotificationSubscriber` filters to `*.created` only — no agent self-email risk.

## Test plan

- [x] `bundle exec rubocop --parallel` → 458 files, 0 offenses (CI parity)
- [x] `bundle exec rake project:tests` → 681 examples, 0 failures, 2 pending (pre-existing)
- [x] `bundle exec rake project:system-tests` → 79 examples, 0 failures
- [x] Live `tools/list` → 23 tools, all 11 new present
- [x] Runtime smoke: read tools (HTML body, all trip states), checklist create-chain, comment edit/delete
- [x] State guard rejects writes on archived trips
- [x] Auth intact (`X-Agent-Identifier: ghost` → `-32001`)

## Note

Depends on the env fix already merged in #140. One follow-up owed: a dedicated issue for the deferred `Rails/StrongParametersExpect` migration across 14 controllers (deferred in #140, not dropped).

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)