### PR TITLE
Stage prod SeaweedFS accessory + migration plan (#44)

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -94,8 +94,10 @@ volumes:
 #
 # Exposure — operator chose SSH-tunnel-only:
 #   • S3 API :8333 is NOT published. Only the app reaches it over the
-#     private `kamal` Docker network at http://seaweedfs:8333
-#     (Kamal registers the accessory on that network under its name).
+#     private `kamal` Docker network at http://seaweedfs:8333. The
+#     `service: seaweedfs` key pins the container/network name to
+#     exactly `seaweedfs` (without it Kamal would name it
+#     `catalyst-seaweedfs` and the endpoint above would not resolve).
 #   • Admin/filer UI is bound to 127.0.0.1 on the host (never the
 #     internet). Reach it from a workstation with:
 #       ssh -L 9333:127.0.0.1:9333 -L 8888:127.0.0.1:8888 deploy@workeverywhere.app
@@ -108,15 +110,24 @@ volumes:
 # (prod analogue of bin/cli storage ensure_bucket / ensure_cors).
 accessories:
   seaweedfs:
+    # Pin the container/network name to `seaweedfs` so the app's
+    # SEAWEEDFS_ENDPOINT (http://seaweedfs:8333) resolves on the
+    # `kamal` net. Default would be `<service>-<accessory>` =
+    # `catalyst-seaweedfs`.
+    service: seaweedfs
     image: chrislusf/seaweedfs:3.97
     host: workeverywhere.app
     cmd: server -s3 -dir=/data -ip.bind=0.0.0.0
     volumes:
       - "catalyst_seaweedfs:/data"
-    ports:
-      - "127.0.0.1:9333:9333"  # master UI  — SSH tunnel only
-      - "127.0.0.1:8888:8888"  # filer UI   — SSH tunnel only
-      # S3 :8333 deliberately NOT published — private `kamal` net only.
+    # Kamal accessories take a single `port:`; multiple published
+    # ports go through `options.publish` (→ docker run --publish).
+    # Both bound to 127.0.0.1 — admin UIs are SSH-tunnel-only; S3
+    # :8333 is deliberately NOT published (private `kamal` net only).
+    options:
+      publish:
+        - "127.0.0.1:9333:9333"  # master UI — SSH tunnel only
+        - "127.0.0.1:8888:8888"  # filer UI  — SSH tunnel only
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -48,6 +48,20 @@ env:
     NOTIF_MAIL_PORT: 587
     NOTIF_MAIL_FROM: catalyst@joelazemar.com
 
+    # SeaweedFS (Active Storage S3 backend) — STAGED for #44, INERT today.
+    # production.rb still pins config.active_storage.service = :local, so
+    # these are read only AFTER the one-time blob migration flips prod to
+    # :seaweedfs (see prompts/Issue 44 - SeaweedFS Migration Plan.md).
+    # Endpoint is the in-cluster accessory over the private `kamal`
+    # network (plain HTTP, never internet-exposed). S3 stays anonymous
+    # ("any"/"any") as in dev — not internet-reachable, so unauthenticated
+    # is acceptable; #44 may harden via SeaweedFS -s3.config if that ever
+    # changes. ssl_verify_peer in storage.yml is moot over http://.
+    SEAWEEDFS_ENDPOINT: http://seaweedfs:8333
+    SEAWEEDFS_BUCKET: catalyst
+    SEAWEEDFS_ACCESS_KEY_ID: any
+    SEAWEEDFS_SECRET_ACCESS_KEY: any
+
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3
 
@@ -71,6 +85,38 @@ aliases:
 # as it hides migrations, seeds, and schema from the image on each deploy.
 volumes:
   - "catalyst_storage:/rails/storage"
+
+# SeaweedFS S3 object store backing Active Storage in production.
+# STAGED (Phase 23b / #44): booting this is harmless while the app
+# still uses :local — production.rb does NOT flip to :seaweedfs until
+# the one-time local→SeaweedFS blob migration runs (runbook in
+# prompts/Issue 44 - SeaweedFS Migration Plan.md, tracked in #44).
+#
+# Exposure — operator chose SSH-tunnel-only:
+#   • S3 API :8333 is NOT published. Only the app reaches it over the
+#     private `kamal` Docker network at http://seaweedfs:8333
+#     (Kamal registers the accessory on that network under its name).
+#   • Admin/filer UI is bound to 127.0.0.1 on the host (never the
+#     internet). Reach it from a workstation with:
+#       ssh -L 9333:127.0.0.1:9333 -L 8888:127.0.0.1:8888 deploy@workeverywhere.app
+#     then open http://localhost:9333 (master) / http://localhost:8888 (filer).
+#
+# Boot/maintenance:
+#   bin/kamal accessory boot seaweedfs
+#   bin/kamal accessory logs seaweedfs
+# The bucket + CORS are provisioned by the migration runbook step 2
+# (prod analogue of bin/cli storage ensure_bucket / ensure_cors).
+accessories:
+  seaweedfs:
+    image: chrislusf/seaweedfs:3.97
+    host: workeverywhere.app
+    cmd: server -s3 -dir=/data -ip.bind=0.0.0.0
+    volumes:
+      - "catalyst_seaweedfs:/data"
+    ports:
+      - "127.0.0.1:9333:9333"  # master UI  — SSH tunnel only
+      - "127.0.0.1:8888:8888"  # filer UI   — SSH tunnel only
+      # S3 :8333 deliberately NOT published — private `kamal` net only.
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,10 +21,13 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Stays :local until #44 ships the prod cutover: a deployed SeaweedFS
-  # service, SEAWEEDFS_* env in config/deploy.yml, and the one-time
-  # blob migration. Flipping this before that infra exists would route
-  # prod uploads to the default localhost:8333 and break them.
+  # Stays :local until #44 ships the prod cutover. The SeaweedFS
+  # accessory and SEAWEEDFS_* env are now STAGED in config/deploy.yml
+  # (inert until this flips). The remaining gate is the one-time
+  # local→SeaweedFS blob migration — runbook in
+  # `prompts/Issue 44 - SeaweedFS Migration Plan.md`. Flip this to
+  # :seaweedfs ONLY as the final, post-migration step (step 6), or
+  # already-stored prod blobs 404.
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.

--- a/prompts/Issue 44 - SeaweedFS Migration Plan.md
+++ b/prompts/Issue 44 - SeaweedFS Migration Plan.md
@@ -16,7 +16,12 @@ branch's runtime behaviour.
 
 - `accessories.seaweedfs`: `chrislusf/seaweedfs:3.97` (matches dev),
   `server -s3 -dir=/data -ip.bind=0.0.0.0`, named volume
-  `catalyst_seaweedfs:/data`, host `workeverywhere.app`.
+  `catalyst_seaweedfs:/data`, host `workeverywhere.app`. Pins
+  `service: seaweedfs` so the container/network name is exactly
+  `seaweedfs` (Kamal would otherwise name it `catalyst-seaweedfs`
+  and `SEAWEEDFS_ENDPOINT` would not resolve). Admin UI ports go
+  through `options.publish` (a Kamal accessory takes a single
+  `port:`; the list form is silently ignored).
 - `env.clear`: `SEAWEEDFS_ENDPOINT=http://seaweedfs:8333`,
   `SEAWEEDFS_BUCKET=catalyst`, anonymous `any/any` keys (S3 is not
   internet-reachable, so unauthenticated is acceptable; harden via
@@ -29,7 +34,7 @@ auth-proxy:
 
 - **S3 API `:8333`** is **not** published — only the app reaches it
   over the private `kamal` Docker network at `http://seaweedfs:8333`
-  (Kamal registers the accessory on that network under its name).
+  (the `service: seaweedfs` key makes that the container/DNS name).
 - **Master/filer admin UI** is published bound to `127.0.0.1` on the
   host only (never the internet). Reach it from a workstation with:
 

--- a/prompts/Issue 44 - SeaweedFS Migration Plan.md
+++ b/prompts/Issue 44 - SeaweedFS Migration Plan.md
@@ -1,0 +1,93 @@
+# Issue #44 — Production Active Storage → SeaweedFS Migration Plan
+
+Tracking issue: [#44](https://github.com/joel/trip/issues/44) — *Switch
+production Active Storage to SeaweedFS for durable persistence.*
+
+Status: **Kamal config STAGED, cutover NOT executed.** `production.rb`
+deliberately stays `config.active_storage.service = :local`; the flip
+is the final post-migration step (step 6), not part of any feature
+branch's runtime behaviour.
+
+---
+
+## Kamal config (staged, inert today)
+
+`config/deploy.yml`:
+
+- `accessories.seaweedfs`: `chrislusf/seaweedfs:3.97` (matches dev),
+  `server -s3 -dir=/data -ip.bind=0.0.0.0`, named volume
+  `catalyst_seaweedfs:/data`, host `workeverywhere.app`.
+- `env.clear`: `SEAWEEDFS_ENDPOINT=http://seaweedfs:8333`,
+  `SEAWEEDFS_BUCKET=catalyst`, anonymous `any/any` keys (S3 is not
+  internet-reachable, so unauthenticated is acceptable; harden via
+  SeaweedFS `-s3.config` if S3 ever gets exposed).
+
+### Exposure — SSH-tunnel-only (operator decision)
+
+kamal-proxy has no built-in basic-auth, so rather than a fragile
+auth-proxy:
+
+- **S3 API `:8333`** is **not** published — only the app reaches it
+  over the private `kamal` Docker network at `http://seaweedfs:8333`
+  (Kamal registers the accessory on that network under its name).
+- **Master/filer admin UI** is published bound to `127.0.0.1` on the
+  host only (never the internet). Reach it from a workstation with:
+
+  ```
+  ssh -L 9333:127.0.0.1:9333 -L 8888:127.0.0.1:8888 deploy@workeverywhere.app
+  ```
+
+  then open `http://localhost:9333` (master) / `http://localhost:8888`
+  (filer). Zero internet exposure, no extra moving parts.
+
+Boot / maintenance:
+
+```
+bin/kamal accessory boot seaweedfs
+bin/kamal accessory logs seaweedfs
+```
+
+---
+
+## Migration runbook — local Disk → SeaweedFS (one-time, zero-loss)
+
+Recommended low-risk path = **Mirror service** (dual-write, then
+backfill, then cut over) so no upload is lost during the window.
+
+0. **Pre-flight.** Tag the box; snapshot the `catalyst_storage`
+   volume. App still `:local`. Record baseline
+   `ActiveStorage::Blob.count` and total bytes.
+1. **Boot the accessory.** `bin/kamal accessory boot seaweedfs`;
+   verify health via the SSH tunnel (master UI cluster status, volume
+   server present).
+2. **Provision bucket + CORS** on prod SeaweedFS (prod analogue of
+   `bin/cli storage` `ensure_bucket` / `ensure_cors`): `PUT /catalyst`
+   (idempotent; HTTP 409 = already owned), and `PUT /catalyst?cors`
+   with `AllowedOrigin https://catalyst.workeverywhere.app`. One-shot
+   rake/runner, idempotent.
+3. **Dual-write window.** Add a `mirror` service to
+   `config/storage.yml` (`primary: local`, `mirrors: [seaweedfs]`) and
+   point `production.rb` at `:mirror`; deploy. Every new/updated blob
+   is now written to **both** stores — no migration race.
+4. **Backfill existing blobs.** Runner task:
+   `ActiveStorage::Blob.find_each` → skip if
+   `seaweedfs.exist?(blob.key)` (idempotent/resumable) → stream
+   `local.download(key)` → `seaweedfs.upload(key, io,
+   checksum: blob.checksum)`. Log every key; never delete the source.
+5. **Verify.** For every blob: `seaweedfs.exist?(key)` true; sample
+   (≥ N random + every video/poster) downloaded and checksum-compared
+   to `blob.checksum`. Counts/bytes reconcile to the step-0 baseline.
+6. **Cut over.** Flip `production.rb` to
+   `config.active_storage.service = :seaweedfs`; deploy. New writes
+   are now SeaweedFS-only; reads served via the
+   `/rails/active_storage/…` proxy from SeaweedFS.
+7. **Smoke (full journeys).** Web: upload a new journal image **and**
+   a video (Direct Upload → SeaweedFS → ProcessJournalVideosJob →
+   ready → lightbox plays). Existing images/exports still render. MCP
+   `add/upload_journal_images|videos` write to SeaweedFS.
+8. **Rollback (safe until decommission).** Revert `production.rb` to
+   `:local` (or `:mirror`) and redeploy — the backfill is read-only on
+   the source, so `catalyst_storage` is intact the whole time.
+9. **Decommission.** After a soak period with `:seaweedfs` healthy,
+   stop relying on `catalyst_storage` for Active Storage (keep the
+   volume — the SQLite DBs live there too). Close #44.


### PR DESCRIPTION
## Summary

Stages the production SeaweedFS infrastructure on the Kamal config and documents the local→SeaweedFS migration runbook. **Staged, not executed** — `production.rb` deliberately stays `config.active_storage.service = :local`; nothing here changes production storage behaviour. The cutover is the final post-migration step, gated on #44.

Split out of the Phase 23b video-pipeline branch (PR #152) to keep that PR scoped and let this infra change be reviewed independently.

## Changes

- **`config/deploy.yml`** — `accessories.seaweedfs` (`chrislusf/seaweedfs:3.97`, named volume `catalyst_seaweedfs:/data`, host `workeverywhere.app`) + staged `SEAWEEDFS_*` env. Inert while the app is on `:local`.
- **`config/environments/production.rb`** — unchanged behaviour (`:local`); comment now points at the runbook and states the flip is the post-migration step only.
- **`prompts/Issue 44 - SeaweedFS Migration Plan.md`** — full zero-loss runbook (Mirror dual-write → backfill → checksum verify → cut over → safe rollback → decommission).

## Exposure decision — SSH-tunnel-only

kamal-proxy has no built-in basic-auth, so rather than a fragile auth-proxy:

- S3 API `:8333` is **not** published — only the app reaches it over the private `kamal` Docker network at `http://seaweedfs:8333`.
- Master/filer admin UI is published bound to `127.0.0.1` only; reached via `ssh -L 9333:127.0.0.1:9333 -L 8888:127.0.0.1:8888 deploy@workeverywhere.app`. Zero internet exposure.

## Validation

- `config/deploy.yml` parses as valid YAML; accessory/env structure verified.
- No runtime code touched — no test/CI impact (config + docs only).

## Not in scope (gated on #44)

Booting the accessory, provisioning bucket/CORS, the dual-write window, the backfill, and the `:seaweedfs` cut-over. Those are the runbook steps, executed under #44 — not here.

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)