### PR TITLE
Cut prod Active Storage over to SeaweedFS via Mirror dual-write (#44)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,14 +21,14 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Stays :local until #44 ships the prod cutover. The SeaweedFS
-  # accessory and SEAWEEDFS_* env are now STAGED in config/deploy.yml
-  # (inert until this flips). The remaining gate is the one-time
-  # local→SeaweedFS blob migration — runbook in
-  # `prompts/Issue 44 - SeaweedFS Migration Plan.md`. Flip this to
-  # :seaweedfs ONLY as the final, post-migration step (step 6), or
-  # already-stored prod blobs 404.
-  config.active_storage.service = :local
+  # Dual-write window for the #44 cutover. :mirror writes every new
+  # upload to BOTH :local (primary) and :seaweedfs; reads still come
+  # from :local, so existing blobs render unchanged. After this is
+  # deployed, run `rake seaweedfs:backfill` to copy existing blobs,
+  # then `rake seaweedfs:verify` (hard gate), then flip this to
+  # :seaweedfs as the final cutover step.
+  # See `prompts/Issue 44 - SeaweedFS Migration Plan.md`.
+  config.active_storage.service = :mirror
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -37,3 +37,15 @@ seaweedfs:
   # Dev/test SeaweedFS sits behind the local self-signed Traefik cert;
   # only production verifies the peer (real endpoint/cert).
   ssl_verify_peer: <%= Rails.env.production? %>
+
+# Dual-write window for the #44 prod cutover. With production.rb set to
+# :mirror, new uploads write to BOTH :local (primary) and :seaweedfs;
+# reads come from :local — so the app keeps serving existing blobs
+# unchanged while new ones land on both stores. Combined with
+# `rake seaweedfs:backfill` for existing blobs, this is the zero-loss
+# path to the final :seaweedfs cutover.
+mirror:
+  service: Mirror
+  primary: local
+  mirrors:
+    - seaweedfs

--- a/lib/tasks/seaweedfs.rake
+++ b/lib/tasks/seaweedfs.rake
@@ -1,27 +1,84 @@
 # frozen_string_literal: true
 
 # Operator runbook tasks for the #44 production cutover from :local
-# Active Storage to :seaweedfs (SeaweedFS S3). Mirror the dev-side
+# Active Storage to :seaweedfs (SeaweedFS S3). Mirrors the dev-side
 # helpers in bin/cli-files/storage-cmd/storage_service.rb so the
 # server-side flow is the same shape.
 #
-# Run inside the app container:
+# Run inside the app container, in this order:
 #   bin/kamal app exec "bin/rails seaweedfs:ensure_bucket"
 #   bin/kamal app exec "bin/rails seaweedfs:backfill"
 #   bin/kamal app exec "bin/rails seaweedfs:verify"
+#   bin/kamal app exec "bin/rails seaweedfs:promote_service_names"
+#   bin/kamal app exec "bin/rails seaweedfs:verify_service_names"
+# Then push the cutover commit (production.rb → :seaweedfs) + redeploy.
+#
+# Rollback (only safe while :local still has the bytes):
+#   bin/kamal app exec "bin/rails seaweedfs:demote_service_names"
 
 CORS_ALLOWED_ORIGIN = "https://catalyst.workeverywhere.app"
 
 # Helpers for seaweedfs:* tasks. Top-level (not inside the namespace
-# block) to satisfy Lint/ConstantDefinitionInBlock.
+# block) to satisfy Lint/ConstantDefinitionInBlock, and to keep each
+# task body small (Metrics/BlockLength).
 module SeaweedfsTasks
   module_function
 
   def local_service = ActiveStorage::Blob.services.fetch(:local)
   def seaweedfs_service = ActiveStorage::Blob.services.fetch(:seaweedfs)
 
-  # Returns :uploaded or :skipped. Raises on real errors so the caller
-  # can count + log per-blob without aborting the whole run.
+  def ensure_bucket!
+    s3 = seaweedfs_service.client.client
+    bucket = seaweedfs_service.bucket.name
+
+    begin
+      s3.create_bucket(bucket: bucket)
+      puts "bucket created: #{bucket}"
+    rescue Aws::S3::Errors::BucketAlreadyOwnedByYou,
+           Aws::S3::Errors::BucketAlreadyExists
+      puts "bucket exists: #{bucket}"
+    end
+
+    s3.put_bucket_cors(bucket: bucket, cors_configuration: cors_configuration)
+    puts "CORS set: #{CORS_ALLOWED_ORIGIN}"
+  end
+
+  def cors_configuration
+    { cors_rules: [{
+      allowed_origins: [CORS_ALLOWED_ORIGIN],
+      allowed_methods: %w[PUT GET HEAD],
+      allowed_headers: ["*"],
+      expose_headers: ["ETag"],
+      max_age_seconds: 3000
+    }] }
+  end
+
+  def backfill!
+    total = ActiveStorage::Blob.count
+    counts = { uploaded: 0, skipped: 0, failed: 0 }
+    failures = []
+
+    ActiveStorage::Blob.find_each.with_index(1) do |blob, i|
+      backfill_one(blob, counts, failures)
+      puts "[#{i}/#{total}] #{counts.inspect}" if (i % 25).zero? || i == total
+    end
+
+    puts "----"
+    puts "total: #{total}  #{counts.inspect}"
+    failures.each { |f| puts "  FAILED #{f[:key]}: #{f[:error]}" }
+    abort "Backfill had failures — re-run after addressing." if counts[:failed].positive?
+  end
+
+  # Returns :uploaded or :skipped. Per-blob rescue: one bad blob never
+  # aborts the whole run; counted + logged, the task aborts at the end.
+  def backfill_one(blob, counts, failures)
+    counts[copy_blob(blob)] += 1
+  rescue StandardError => e
+    counts[:failed] += 1
+    failures << { key: blob.key, error: "#{e.class}: #{e.message}" }
+    Rails.logger.error("[seaweedfs:backfill] #{blob.key}: #{e.class}: #{e.message}")
+  end
+
   def copy_blob(blob)
     return :skipped if seaweedfs_service.exist?(blob.key)
 
@@ -33,97 +90,107 @@ module SeaweedfsTasks
     :uploaded
   end
 
-  # Stream the remote blob through MD5 (Active Storage's checksum is
-  # base64(md5)); avoids loading the whole file into memory.
+  def verify_bytes!
+    total = ActiveStorage::Blob.count
+    missing = ActiveStorage::Blob.find_each.reject { |b| seaweedfs_service.exist?(b.key) }.map(&:key)
+    mismatched = checksum_sample(total, missing)
+
+    puts "blobs: #{total}, missing: #{missing.size}, mismatched: #{mismatched.size}"
+    puts "service_name distribution: #{service_name_distribution.inspect}"
+    missing.first(20).each { |k| puts "  MISSING #{k}" }
+    mismatched.each { |m| puts "  MISMATCH #{m.inspect}" }
+    abort "Verify FAILED — DO NOT promote/flip" if missing.any? || mismatched.any?
+
+    puts "OK — bytes verified. Next: rake seaweedfs:promote_service_names"
+  end
+
+  # Sample: every video + a random ~5% of the rest (min 5). Streams MD5
+  # to avoid loading whole blobs into memory.
+  def checksum_sample(total, missing)
+    others_size = [(total / 20.0).ceil, 5].max
+    videos = ActiveStorage::Blob.where("content_type LIKE 'video/%'").to_a
+    others = ActiveStorage::Blob.where.not("content_type LIKE 'video/%'")
+                                .order(Arel.sql("RANDOM()")).limit(others_size).to_a
+    (videos + others).uniq(&:id).filter_map do |blob|
+      next if missing.include?(blob.key)
+
+      got = remote_md5(blob.key)
+      next if got == blob.checksum
+
+      { key: blob.key, expected: blob.checksum, got: got }
+    rescue StandardError => e
+      { key: blob.key, error: "#{e.class}: #{e.message}" }
+    end
+  end
+
   def remote_md5(key)
     digest = Digest::MD5.new
     seaweedfs_service.download(key) { |chunk| digest << chunk }
     Base64.strict_encode64(digest.digest)
+  end
+
+  def service_name_distribution = ActiveStorage::Blob.group(:service_name).count
+
+  # rubocop:disable Rails/SkipsModelValidations -- bulk service_name rewrite, no model invariants involved
+  def rewrite_service_name(from:, to:)
+    ActiveStorage::Blob.where(service_name: from).update_all(service_name: to)
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  def print_rewrite(label:, before:, count:)
+    puts "before:  #{before.inspect}"
+    puts "#{label}: #{count}"
+    puts "after:   #{service_name_distribution.inspect}"
+  end
+
+  # Rails' Blob#service consults the persisted service_name first; with
+  # ActiveStorageBlobBuilder (app/lib/active_storage_blob_builder.rb)
+  # explicitly storing service_name on every row, simply flipping the
+  # default service does NOT move reads to :seaweedfs — existing
+  # service_name="local" / "mirror" rows still resolve to the old
+  # service. This task is the actual read-cutover.
+  def verify_service_names!
+    by_service = service_name_distribution
+    puts "service_name distribution: #{by_service.inspect}"
+    stragglers = by_service.except("seaweedfs")
+    abort "service_name verify FAILED — #{stragglers.inspect} still on old service" if stragglers.any?
+
+    puts "OK — every blob has service_name='seaweedfs'. Safe to flip production.rb."
   end
 end
 
 namespace :seaweedfs do
   desc "Provision the SeaweedFS bucket + CORS policy (idempotent)"
   task ensure_bucket: :environment do
-    svc = ActiveStorage::Blob.services.fetch(:seaweedfs)
-    s3 = svc.client.client
-    bucket = svc.bucket.name
-
-    begin
-      s3.create_bucket(bucket: bucket)
-      puts "bucket created: #{bucket}"
-    rescue Aws::S3::Errors::BucketAlreadyOwnedByYou,
-           Aws::S3::Errors::BucketAlreadyExists
-      puts "bucket exists: #{bucket}"
-    end
-
-    s3.put_bucket_cors(
-      bucket: bucket,
-      cors_configuration: {
-        cors_rules: [{
-          allowed_origins: [CORS_ALLOWED_ORIGIN],
-          allowed_methods: %w[PUT GET HEAD],
-          allowed_headers: ["*"],
-          expose_headers: ["ETag"],
-          max_age_seconds: 3000
-        }]
-      }
-    )
-    puts "CORS set: #{CORS_ALLOWED_ORIGIN}"
+    SeaweedfsTasks.ensure_bucket!
   end
 
   desc "Backfill existing :local blobs to :seaweedfs (idempotent, resumable)"
   task backfill: :environment do
-    total = ActiveStorage::Blob.count
-    counts = { uploaded: 0, skipped: 0, failed: 0 }
-    failures = []
-
-    ActiveStorage::Blob.find_each.with_index(1) do |blob, i|
-      begin
-        result = SeaweedfsTasks.copy_blob(blob)
-        counts[result] += 1
-      rescue StandardError => e
-        counts[:failed] += 1
-        failures << { key: blob.key, error: "#{e.class}: #{e.message}" }
-        Rails.logger.error("[seaweedfs:backfill] #{blob.key}: #{e.class}: #{e.message}")
-      end
-      puts "[#{i}/#{total}] #{counts.inspect}" if (i % 25).zero? || i == total
-    end
-
-    puts "----"
-    puts "total: #{total}  #{counts.inspect}"
-    failures.each { |f| puts "  FAILED #{f[:key]}: #{f[:error]}" }
-    abort "Backfill had failures — re-run after addressing." if counts[:failed].positive?
+    SeaweedfsTasks.backfill!
   end
 
-  desc "Verify every blob exists on :seaweedfs; checksum a sample (hard gate before cutover)"
+  desc "Verify every blob exists on :seaweedfs; checksum a sample (hard gate before promote)"
   task verify: :environment do
-    total = ActiveStorage::Blob.count
-    missing = ActiveStorage::Blob.find_each.reject { |b| SeaweedfsTasks.seaweedfs_service.exist?(b.key) }.map(&:key)
+    SeaweedfsTasks.verify_bytes!
+  end
 
-    # Sample: every video + a random ~5% of the rest (min 5).
-    videos = ActiveStorage::Blob.where("content_type LIKE 'video/%'")
-    others_sample_size = [(total / 20.0).ceil, 5].max
-    others = ActiveStorage::Blob.where.not("content_type LIKE 'video/%'")
-                                .order(Arel.sql("RANDOM()")).limit(others_sample_size)
-    mismatched = []
+  desc "Rewrite blob service_name from local/mirror to seaweedfs (read cutover)"
+  task promote_service_names: :environment do
+    before = SeaweedfsTasks.service_name_distribution
+    count = SeaweedfsTasks.rewrite_service_name(from: %w[local mirror], to: "seaweedfs")
+    SeaweedfsTasks.print_rewrite(label: "promoted", before: before, count: count)
+  end
 
-    (videos.to_a + others.to_a).uniq(&:id).each do |blob|
-      next if missing.include?(blob.key)
+  desc "Rollback: rewrite blob service_name from seaweedfs back to local"
+  task demote_service_names: :environment do
+    before = SeaweedfsTasks.service_name_distribution
+    count = SeaweedfsTasks.rewrite_service_name(from: "seaweedfs", to: "local")
+    SeaweedfsTasks.print_rewrite(label: "demoted ", before: before, count: count)
+  end
 
-      got = SeaweedfsTasks.remote_md5(blob.key)
-      next if got == blob.checksum
-
-      mismatched << { key: blob.key, expected: blob.checksum, got: got }
-    rescue StandardError => e
-      mismatched << { key: blob.key, error: "#{e.class}: #{e.message}" }
-    end
-
-    puts "blobs: #{total}, missing: #{missing.size}, mismatched: #{mismatched.size}"
-    missing.first(20).each { |k| puts "  MISSING #{k}" }
-    mismatched.each { |m| puts "  MISMATCH #{m.inspect}" }
-    abort "Verify FAILED — DO NOT flip to :seaweedfs" if missing.any? || mismatched.any?
-
-    puts "OK — safe to flip production to :seaweedfs"
+  desc "Assert every blob has service_name='seaweedfs' (final gate before flipping production.rb)"
+  task verify_service_names: :environment do
+    SeaweedfsTasks.verify_service_names!
   end
 end

--- a/lib/tasks/seaweedfs.rake
+++ b/lib/tasks/seaweedfs.rake
@@ -12,6 +12,36 @@
 
 CORS_ALLOWED_ORIGIN = "https://catalyst.workeverywhere.app"
 
+# Helpers for seaweedfs:* tasks. Top-level (not inside the namespace
+# block) to satisfy Lint/ConstantDefinitionInBlock.
+module SeaweedfsTasks
+  module_function
+
+  def local_service = ActiveStorage::Blob.services.fetch(:local)
+  def seaweedfs_service = ActiveStorage::Blob.services.fetch(:seaweedfs)
+
+  # Returns :uploaded or :skipped. Raises on real errors so the caller
+  # can count + log per-blob without aborting the whole run.
+  def copy_blob(blob)
+    return :skipped if seaweedfs_service.exist?(blob.key)
+
+    local_service.open(blob.key) do |io|
+      seaweedfs_service.upload(blob.key, io,
+                               checksum: blob.checksum,
+                               content_type: blob.content_type)
+    end
+    :uploaded
+  end
+
+  # Stream the remote blob through MD5 (Active Storage's checksum is
+  # base64(md5)); avoids loading the whole file into memory.
+  def remote_md5(key)
+    digest = Digest::MD5.new
+    seaweedfs_service.download(key) { |chunk| digest << chunk }
+    Base64.strict_encode64(digest.digest)
+  end
+end
+
 namespace :seaweedfs do
   desc "Provision the SeaweedFS bucket + CORS policy (idempotent)"
   task ensure_bucket: :environment do
@@ -40,5 +70,60 @@ namespace :seaweedfs do
       }
     )
     puts "CORS set: #{CORS_ALLOWED_ORIGIN}"
+  end
+
+  desc "Backfill existing :local blobs to :seaweedfs (idempotent, resumable)"
+  task backfill: :environment do
+    total = ActiveStorage::Blob.count
+    counts = { uploaded: 0, skipped: 0, failed: 0 }
+    failures = []
+
+    ActiveStorage::Blob.find_each.with_index(1) do |blob, i|
+      begin
+        result = SeaweedfsTasks.copy_blob(blob)
+        counts[result] += 1
+      rescue StandardError => e
+        counts[:failed] += 1
+        failures << { key: blob.key, error: "#{e.class}: #{e.message}" }
+        Rails.logger.error("[seaweedfs:backfill] #{blob.key}: #{e.class}: #{e.message}")
+      end
+      puts "[#{i}/#{total}] #{counts.inspect}" if (i % 25).zero? || i == total
+    end
+
+    puts "----"
+    puts "total: #{total}  #{counts.inspect}"
+    failures.each { |f| puts "  FAILED #{f[:key]}: #{f[:error]}" }
+    abort "Backfill had failures — re-run after addressing." if counts[:failed].positive?
+  end
+
+  desc "Verify every blob exists on :seaweedfs; checksum a sample (hard gate before cutover)"
+  task verify: :environment do
+    total = ActiveStorage::Blob.count
+    missing = ActiveStorage::Blob.find_each.reject { |b| SeaweedfsTasks.seaweedfs_service.exist?(b.key) }.map(&:key)
+
+    # Sample: every video + a random ~5% of the rest (min 5).
+    videos = ActiveStorage::Blob.where("content_type LIKE 'video/%'")
+    others_sample_size = [(total / 20.0).ceil, 5].max
+    others = ActiveStorage::Blob.where.not("content_type LIKE 'video/%'")
+                                .order(Arel.sql("RANDOM()")).limit(others_sample_size)
+    mismatched = []
+
+    (videos.to_a + others.to_a).uniq(&:id).each do |blob|
+      next if missing.include?(blob.key)
+
+      got = SeaweedfsTasks.remote_md5(blob.key)
+      next if got == blob.checksum
+
+      mismatched << { key: blob.key, expected: blob.checksum, got: got }
+    rescue StandardError => e
+      mismatched << { key: blob.key, error: "#{e.class}: #{e.message}" }
+    end
+
+    puts "blobs: #{total}, missing: #{missing.size}, mismatched: #{mismatched.size}"
+    missing.first(20).each { |k| puts "  MISSING #{k}" }
+    mismatched.each { |m| puts "  MISMATCH #{m.inspect}" }
+    abort "Verify FAILED — DO NOT flip to :seaweedfs" if missing.any? || mismatched.any?
+
+    puts "OK — safe to flip production to :seaweedfs"
   end
 end

--- a/lib/tasks/seaweedfs.rake
+++ b/lib/tasks/seaweedfs.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Operator runbook tasks for the #44 production cutover from :local
+# Active Storage to :seaweedfs (SeaweedFS S3). Mirror the dev-side
+# helpers in bin/cli-files/storage-cmd/storage_service.rb so the
+# server-side flow is the same shape.
+#
+# Run inside the app container:
+#   bin/kamal app exec "bin/rails seaweedfs:ensure_bucket"
+#   bin/kamal app exec "bin/rails seaweedfs:backfill"
+#   bin/kamal app exec "bin/rails seaweedfs:verify"
+
+CORS_ALLOWED_ORIGIN = "https://catalyst.workeverywhere.app"
+
+namespace :seaweedfs do
+  desc "Provision the SeaweedFS bucket + CORS policy (idempotent)"
+  task ensure_bucket: :environment do
+    svc = ActiveStorage::Blob.services.fetch(:seaweedfs)
+    s3 = svc.client.client
+    bucket = svc.bucket.name
+
+    begin
+      s3.create_bucket(bucket: bucket)
+      puts "bucket created: #{bucket}"
+    rescue Aws::S3::Errors::BucketAlreadyOwnedByYou,
+           Aws::S3::Errors::BucketAlreadyExists
+      puts "bucket exists: #{bucket}"
+    end
+
+    s3.put_bucket_cors(
+      bucket: bucket,
+      cors_configuration: {
+        cors_rules: [{
+          allowed_origins: [CORS_ALLOWED_ORIGIN],
+          allowed_methods: %w[PUT GET HEAD],
+          allowed_headers: ["*"],
+          expose_headers: ["ETag"],
+          max_age_seconds: 3000
+        }]
+      }
+    )
+    puts "CORS set: #{CORS_ALLOWED_ORIGIN}"
+  end
+end


### PR DESCRIPTION
## Summary

Executes the migration runbook from PR #155 / [`prompts/Issue 44 - SeaweedFS Migration Plan.md`](../blob/main/prompts/Issue%2044%20-%20SeaweedFS%20Migration%20Plan.md). Brings up the dual-write window so existing blobs can be backfilled to SeaweedFS without downtime or data loss — same `:local`-as-primary mirror pattern Active Storage ships natively.

Held back from this PR: the final flip of `production.rb` from `:mirror` → `:seaweedfs`. That commit lands only after the operator runs `rake seaweedfs:verify` + `seaweedfs:verify_service_names` clean.

`Refs #44`.

## Changes (5 atomic commits)

| sha | Commit |
|-----|--------|
| `21e475e` | `feat(storage): add Mirror service for #44 dual-write cutover` — `mirror` service in `config/storage.yml` (primary `:local`, mirrors `:seaweedfs`). Inert until production.rb flips. |
| `7e1afa2` | `feat(seaweedfs): add seaweedfs:ensure_bucket rake task` — prod analogue of dev `StorageService` bucket+CORS provisioner. |
| `ed0e5b5` | `feat(seaweedfs): add backfill + verify rake tasks` — idempotent/resumable byte copy + checksum gate. |
| `c13216e` | `feat(storage): flip prod Active Storage to :mirror (dual-write)` — `production.rb` from `:local` to `:mirror`. |
| `235ba32` | `fix(seaweedfs): rewrite blob service_name on cutover` — adds the read-cutover step that was missing (Codex P1 in this PR). Without it, blob rows continue resolving through their persisted `service_name`, so flipping the default never actually cuts over reads. New tasks: `promote_service_names`, `demote_service_names`, `verify_service_names`. |

Test env unaffected — `:test` is still Disk; the `mirror` service is defined but unused outside production.

## Why `promote_service_names` exists

`app/lib/active_storage_blob_builder.rb` explicitly persists `service_name: ActiveStorage::Blob.service.name` on every blob it creates, and Rails' standard `attach(io:)` path does the same internally. `ActiveStorage::Blob#service` consults the persisted `service_name` first — so simply flipping the default Active Storage service does **not** migrate existing rows. Without the rewrite step:

- Existing `service_name="local"` rows keep reading from `:local` after the flip — the cutover doesn't actually cut over.
- Mirror-era `service_name="mirror"` rows go through MirrorService → `:local`; when the mirror block is removed later, `services.fetch("mirror")` raises `KeyError` and every such blob 500s.

The new task UPDATEs all `service_name IN ('local','mirror')` to `'seaweedfs'` in one idempotent SQL statement. That's the actual read-cutover moment — happens *before* the production.rb flip.

## Operator runbook (you execute, I'll help)

Run in order. **Do not skip the verify gates.** Every rake task is idempotent — safe to re-run.

| # | Command | What it does | Verify before next step |
|---|---------|--------------|--------------------------|
| 0 | Confirm `main` is at the cutover PR's merge tip. | — | — |
| 1 | `bin/kamal accessory boot seaweedfs` | Boots the SeaweedFS accessory from #155's deploy.yml. Doesn't touch the app. | `bin/kamal accessory logs seaweedfs` shows master/volume/filer/s3 ports up. Via SSH tunnel (`ssh -L 9333:127.0.0.1:9333 deploy@workeverywhere.app`), master UI shows a healthy volume server. |
| 2 | `bin/kamal app exec "bin/rails seaweedfs:ensure_bucket"` | Provisions bucket + CORS. | Output: `bucket created` / `bucket exists`, then `CORS set: https://catalyst.workeverywhere.app`. |
| 3 | `bin/kamal deploy` | Deploys this PR. App now dual-writes new uploads to `:local` + `:seaweedfs`; reads from `:local`. | Open the site — existing images render normally. Upload one new journal image; via SSH-tunnel filer UI confirm the new blob key is in `/buckets/catalyst/<key>`. |
| 4 | `bin/kamal app exec "bin/rails seaweedfs:backfill"` | Copies every existing blob to SeaweedFS. Resumable. Long-running for a big dataset. | Final line: `total: N {:uploaded=>X, :skipped=>Y, :failed=>0}`. (Re-run is idempotent — `:skipped=>N`.) |
| 5 | `bin/kamal app exec "bin/rails seaweedfs:verify"` | **Bytes gate.** Every blob exists; every video + ~5% sample matches checksum. Also prints `service_name` distribution. | Final line: `OK — bytes verified. Next: rake seaweedfs:promote_service_names`. If not, **stop** — re-run backfill, investigate. |
| 6 | `bin/kamal app exec "bin/rails seaweedfs:promote_service_names"` | **Read cutover.** UPDATE service_name from `('local','mirror')` → `'seaweedfs'` on every blob. From this moment, reads flow from `:seaweedfs` for every promoted blob — no deploy needed. New writes still dual-write via `:mirror` until step 8. | `promoted: N` non-zero on first run; the `after:` line shows everything on `'seaweedfs'`. |
| 7 | `bin/kamal app exec "bin/rails seaweedfs:verify_service_names"` | **Final gate.** Asserts every blob has `service_name='seaweedfs'`. | `OK — every blob has service_name='seaweedfs'. Safe to flip production.rb.` If anything else still on `'local'` or `'mirror'`, **stop**. |
| 8 | I push the cutover commit (`production.rb` → `:seaweedfs`) → `bin/kamal deploy` | New writes now SeaweedFS-only. | Existing images still render; new uploads work; a fresh video Direct Upload still flows ingest → ready → lightbox. |
| 9 | Soak for an interval of your choice | Watch logs/Sentry for 404s/errors. | If anything misbehaves: `bin/kamal app exec "bin/rails seaweedfs:demote_service_names"` instantly restores all reads to `:local` (rollback safe while `:local` has the bytes); then revert `production.rb` to `:mirror` and redeploy. |
| 10 | (Follow-up PR, later) Remove `mirror` block from `storage.yml` | Cleanup once confident — and ONLY after every blob is on `service_name='seaweedfs'` (verified in step 7). The `catalyst_storage` volume stays — SQLite lives there. | — |

## Validation

- `bundle exec rake project:lint`: **509 files, 0 offenses**
- `bundle exec rake project:tests`: **781 examples, 0 failures, 2 pending** (pre-existing)
- `bundle exec rake project:system-tests`: **93/0** (after re-running 2 known timing flakes per #149 class — unrelated to storage; CI uses rack_test so they don't appear there)

Rake tasks intentionally not unit-tested — they're operator runbook tools (same precedent as `bin/cli storage` and `lib/tasks/auth.rake`). The `seaweedfs:verify` / `verify_service_names` steps are the real safety gates, exercised at runbook steps 5 + 7.

## Risk + rollback

- **During mirror window (steps 3–5):** zero user-visible change. Reads still from `:local`; new writes dual-write.
- **After promote (step 6+):** reads come from `:seaweedfs`. If a backfilled blob 404s on SeaweedFS, the image/video shows broken. Rollback: `rake seaweedfs:demote_service_names` instantly restores reads to `:local` (no deploy needed). Backfill is read-only on source, so `:local` is intact throughout.
- **After cutover (step 8+):** new writes are SeaweedFS-only. Rollback then requires reverting `production.rb` + redeploying (back to `:mirror` to resume dual-write); pre-cutover blobs still readable.
- **No DB migrations.** Active Storage schema unchanged; we're moving bytes and rewriting one column, not rows.