### PR TITLE
Disable aws-sdk flexible-checksum; SeaweedFS validates chunked-encoded bytes (#44)

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -37,6 +37,18 @@ seaweedfs:
   # Dev/test SeaweedFS sits behind the local self-signed Traefik cert;
   # only production verifies the peer (real endpoint/cert).
   ssl_verify_peer: <%= Rails.env.production? %>
+  # aws-sdk-s3 1.180+ defaults `request_checksum_calculation` to
+  # `:when_supported`, which adds an `x-amz-trailer` flexible-checksum
+  # and switches to `aws-chunked` body encoding once the body crosses
+  # the inline threshold (~8 KB). SeaweedFS S3 v3.97 computes
+  # validation checksums over the chunked-encoded bytes (not the
+  # decoded body), so any large PUT comes back BadDigest. Forcing
+  # `:when_required` keeps the SDK on plain unchunked PUTs unless the
+  # caller explicitly requests a checksum — which Active Storage
+  # never does. Matches AWS S3 behaviour exactly (AWS still computes
+  # ETag = MD5 server-side); only the SDK-side trailer is skipped.
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required
 
 # Dual-write window for the #44 prod cutover. With production.rb set to
 # :mirror, new uploads write to BOTH :local (primary) and :seaweedfs;

--- a/lib/tasks/seaweedfs.rake
+++ b/lib/tasks/seaweedfs.rake
@@ -79,12 +79,19 @@ module SeaweedfsTasks
     Rails.logger.error("[seaweedfs:backfill] #{blob.key}: #{e.class}: #{e.message}")
   end
 
+  # No `checksum:` kwarg: aws-sdk-s3 1.223 pairs Content-MD5 with
+  # `aws-chunked` streaming encoding once the body crosses the inline
+  # threshold (~8 KB). SeaweedFS S3 v3.97 computes MD5 over the
+  # chunked-encoded bytes rather than the decoded body, so every
+  # non-inline upload comes back BadDigest → ActiveStorage::IntegrityError.
+  # Skipping Content-MD5 sidesteps the trap; integrity is still
+  # validated post-hoc by `seaweedfs:verify` (downloads + MD5 vs
+  # blob.checksum). TCP/TLS protect bytes in flight.
   def copy_blob(blob)
     return :skipped if seaweedfs_service.exist?(blob.key)
 
     local_service.open(blob.key) do |io|
       seaweedfs_service.upload(blob.key, io,
-                               checksum: blob.checksum,
                                content_type: blob.content_type)
     end
     :uploaded


### PR DESCRIPTION
## Summary

Hot-fix during the live #44 cutover. \`bin/rails seaweedfs:backfill\` failed on **379/383** blobs with \`ActiveStorage::IntegrityError\` because aws-sdk-s3 1.223's default flexible-checksum mode is incompatible with SeaweedFS S3 v3.97 once the body crosses the SDK's inline threshold (~8 KB).

The 4 successful blobs were the post-deploy MirrorService writes — all small enough to be sent inline. Any larger fresh upload would have failed next.

## Root cause

- aws-sdk-s3 1.180+ ships with \`request_checksum_calculation: :when_supported\` as default. For PUT bodies above the inline threshold, the SDK switches to **\`aws-chunked\` body encoding** and adds an \`x-amz-trailer\` flexible-checksum.
- SeaweedFS S3 v3.97 computes its validation MD5 over the **chunked-encoded bytes**, not the decoded body. So the Content-MD5 the client sends never matches what the server computes → \`BadDigest\` → Active Storage maps to \`IntegrityError\`.
- AWS S3 itself decodes the chunks before MD5 validation, so this only bites against S3-compatible stores that don't.

## Fix

| File | Change |
|------|--------|
| \`config/storage.yml\` | Add \`request_checksum_calculation: when_required\` + \`response_checksum_validation: when_required\` to the \`seaweedfs\` service. Keeps the SDK on plain unchunked PUTs unless the caller explicitly asks for a checksum. Active Storage never does. |
| \`lib/tasks/seaweedfs.rake\` | Drop the \`checksum:\` kwarg from \`copy_blob\`'s \`upload\` call as defence-in-depth + a comment recording the failure mode. Integrity is still validated post-hoc by \`seaweedfs:verify\` (downloads + MD5 vs \`blob.checksum\`). |

The storage.yml change is the load-bearing one — it fixes the running MirrorService too. The rake task change just adds a paper trail.

## Validation

- \`bundle exec rake project:lint\`: **509 files, 0 offenses**
- \`bundle exec rake project:tests\`: **781 examples, 0 failures, 2 pending**

## Next steps after merge

1. Deploy auto-fires on the merge commit (same as previous PRs).
2. Operator re-runs \`bin/kamal app exec \"bin/rails seaweedfs:backfill\"\` — should now upload all 379 remaining blobs cleanly.
3. Resume cutover at runbook step 5 (\`seaweedfs:verify\`).

\`Refs #44\`.