### PR TITLE
Read DiskService path directly; the Downloader tempfile is the real culprit (#44)

### DIFF
--- a/lib/tasks/seaweedfs.rake
+++ b/lib/tasks/seaweedfs.rake
@@ -72,21 +72,21 @@ module SeaweedfsTasks
     Rails.logger.error("[seaweedfs:backfill] #{blob.key}: #{e.class}: #{e.message}")
   end
 
-  # aws-sdk-s3 1.223 picks `aws-chunked` encoding for Tempfile bodies
-  # and for large bodies when checksums are enabled; SeaweedFS S3
-  # v3.97 then computes MD5 over the chunked bytes -> false BadDigest.
-  # Two precautions: reopen the tempfile as a vanilla File (forces
-  # the SDK's single-PUT path), and omit `checksum:` (with the
-  # :when_required lock in storage.yml — no Content-MD5 sent).
+  # Open the on-disk file directly rather than via local.open (which
+  # yields a Tempfile through ActiveStorage::Downloader). aws-sdk-s3
+  # 1.223 takes a chunked-body code path for Downloader-derived
+  # Tempfile IOs that SeaweedFS S3 v3.97 can't validate, producing
+  # false BadDigest -> IntegrityError on every non-tiny upload —
+  # even after reopening the tempfile's path as a File (which
+  # appeared to work in the initial probe but failed under load).
+  # Reading straight from the DiskService path stays on the SDK's
+  # single-PUT path; validated with 10/10 sequential probes.
   # seaweedfs:verify is the post-hoc integrity gate.
   def copy_blob(blob)
     return :skipped if seaweedfs_service.exist?(blob.key)
 
-    local_service.open(blob.key) do |tempfile|
-      File.open(tempfile.path, "rb") do |io|
-        seaweedfs_service.upload(blob.key, io,
-                                 content_type: blob.content_type)
-      end
+    File.open(local_service.send(:path_for, blob.key), "rb") do |io|
+      seaweedfs_service.upload(blob.key, io, content_type: blob.content_type)
     end
     :uploaded
   end


### PR DESCRIPTION
## Summary

Third hot-fix for the #44 backfill. PR #163's \`File.open(tempfile.path)\` wrapper **looked** like it worked in my initial probe but actually didn't — the original \`T4\` success was a side effect of \`T1\`/\`T2\`/\`T3\` having already run in the same Ruby process. Re-tested fresh today:

| Test | Result |
|------|--------|
| raw \`bucket.object().put(File.open(disk_path))\` | OK |
| \`svc.upload(key, File.open(disk_path))\` | **OK** ← new path |
| \`svc.upload(key, File.open(tempfile.path))\` | FAIL ← #163 path |
| \`svc.upload(key, Downloader_tempfile)\` | FAIL |
| 10 sequential blobs via direct disk path | **OK 10/10** |

The Downloader's tempfile (or anything in its tempdir/lifecycle) trips an aws-sdk-s3 1.223 code path that SeaweedFS S3 v3.97 can't validate (produces false \`BadDigest\` → \`ActiveStorage::IntegrityError\`). Bypassing the Downloader entirely and reading straight from the DiskService's on-disk path stays on the SDK's single-PUT path that SeaweedFS handles correctly.

## Fix

\`lib/tasks/seaweedfs.rake#copy_blob\`:

\`\`\`ruby
File.open(local_service.send(:path_for, blob.key), \"rb\") do |io|
  seaweedfs_service.upload(blob.key, io, content_type: blob.content_type)
end
\`\`\`

\`DiskService#path_for\` is private but stable across Rails versions; \`send\` is the conventional escape hatch. Bonus: faster — no Downloader tempfile round-trip for a source that's already a local file.

The storage.yml \`:when_required\` lock from #162 stays as a defensive pair (still correct for the MirrorService path on fresh uploads).

## Validation

- 10/10 sequential probes uploaded clean against the prod accessory.
- \`bundle exec rubocop lib/tasks/seaweedfs.rake\`: clean.

## Honest note on this saga

#162 fixed a real but secondary issue (the SDK flexible-checksum/aws-chunked interaction). #163 fixed a non-issue I'd misdiagnosed from a misleading probe. This PR is the actual root cause. The diagnostic ladder approach pinpointed the real differentiator (path-derived File vs Downloader-derived Tempfile) only after I caught the probe ordering trap.

\`Refs #44\`.