### PR TITLE
Cut prod Active Storage over to SeaweedFS (closes #44)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,14 +21,15 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Dual-write window for the #44 cutover. :mirror writes every new
-  # upload to BOTH :local (primary) and :seaweedfs; reads still come
-  # from :local, so existing blobs render unchanged. After this is
-  # deployed, run `rake seaweedfs:backfill` to copy existing blobs,
-  # then `rake seaweedfs:verify` (hard gate), then flip this to
-  # :seaweedfs as the final cutover step.
-  # See `prompts/Issue 44 - SeaweedFS Migration Plan.md`.
-  config.active_storage.service = :mirror
+  # #44 cutover complete: every blob backfilled to SeaweedFS,
+  # verified, and service_name promoted to "seaweedfs". Reads and
+  # writes now go straight to the SeaweedFS S3 service. The :mirror
+  # service block in storage.yml is kept available for fast rollback
+  # (revert this to :mirror and redeploy — :local still holds every
+  # blob from before the cutover) and can be removed in a follow-up
+  # PR after a soak period. See `prompts/Issue 44 - SeaweedFS
+  # Migration Plan.md`.
+  config.active_storage.service = :seaweedfs
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true


### PR DESCRIPTION
## Summary

Final commit of the #44 cutover. Flips \`production.rb\` from \`:mirror\` to \`:seaweedfs\` so new writes go to SeaweedFS directly instead of dual-writing via Mirror.

\`Closes #44\`.

## State entering this commit (live, just verified)

- **Bytes**: 383 / 383 blobs on SeaweedFS, \`seaweedfs:verify\` clean (0 missing, 0 mismatched).
- **Reads**: \`service_name\` promoted on every row to \`seaweedfs\`; the read path is already flowing from SeaweedFS — proven by \`seaweedfs:verify_service_names\` returning \`{"seaweedfs" => 383}\`.
- **Writes**: still dual-writing via \`:mirror\` until this commit deploys. After deploy → SeaweedFS-only.

## What this changes

Just \`production.rb\`:

\`\`\`diff
- config.active_storage.service = :mirror
+ config.active_storage.service = :seaweedfs
\`\`\`

Plus the comment update marking the cutover complete.

## Rollback path

The \`:mirror\` service block stays in \`storage.yml\` for a soak window. If anything misbehaves: revert \`production.rb\` to \`:mirror\` and redeploy. \`:local\` still holds every pre-cutover blob untouched; the dual-write resumes immediately.

A follow-up PR can remove the \`:mirror\` block after a soak period.

## Smoke after merge + deploy

- Existing journal images render.
- A fresh image upload via the form works and lands only on SeaweedFS (not in \`/rails/storage/\` anymore).
- A fresh video upload runs through Direct Upload → ProcessJournalVideosJob → lightbox.

I'll run the basic checks after the deploy lands.