### PR TITLE
Roll back: prod Active Storage to :local (SeaweedFS not browser-reachable)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,15 +21,18 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # #44 cutover complete: every blob backfilled to SeaweedFS,
-  # verified, and service_name promoted to "seaweedfs". Reads and
-  # writes now go straight to the SeaweedFS S3 service. The :mirror
-  # service block in storage.yml is kept available for fast rollback
-  # (revert this to :mirror and redeploy — :local still holds every
-  # blob from before the cutover) and can be removed in a follow-up
-  # PR after a soak period. See `prompts/Issue 44 - SeaweedFS
-  # Migration Plan.md`.
-  config.active_storage.service = :seaweedfs
+  # ROLLBACK from the #44 cutover. The cutover broke the browser path:
+  # SeaweedFS S3 is exposed only on the private `kamal` Docker network
+  # (the SSH-tunnel-only design from PR #155), but Active Storage's
+  # Direct Upload and read-redirect URLs both point the BROWSER at
+  # http://seaweedfs:8333/... — unreachable from outside the cluster.
+  # The architectural fix is to expose SeaweedFS at a public HTTPS
+  # subdomain via kamal-proxy (storage.workeverywhere.app), then re-do
+  # the cutover. Until then we stay on :local — every pre-cutover blob
+  # still lives on the catalyst_storage volume, untouched.
+  # service_name has been demoted back to "local" via
+  # `rake seaweedfs:demote_service_names`.
+  config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true


### PR DESCRIPTION
## What happened

The #44 cutover deployed successfully but the **browser** can't read any image and Direct Upload fails immediately with \`Status: 0\`:

- \`config/deploy.yml\` puts SeaweedFS S3 on the private \`kamal\` Docker network (the SSH-tunnel-only design from #155).
- Active Storage with S3 generates URLs against the configured endpoint. With \`SEAWEEDFS_ENDPOINT=http://seaweedfs:8333\`, every read-redirect and every Direct-Upload PUT URL points at \`http://seaweedfs:8333/...\`.
- The browser can't resolve \`seaweedfs\`, and port \`8333\` isn't published. Connection refused.

My CLI smoke tests passed because \`bin/kamal app exec\` runs *inside* the Docker network. I missed that real users go through the browser. This was my call — the SSH-tunnel-only model was correct for the admin UI but wrong for the S3 API.

## Rollback

| Step | Action | State |
|------|--------|-------|
| 1 | \`rake seaweedfs:demote_service_names\` (run live) | All 385 blob rows back to \`service_name='local'\`; reads serve from \`:local\` via the app endpoint immediately, no deploy needed |
| 2 | **This commit** | \`production.rb\` back to \`:local\`; new uploads also use the working path |

The \`catalyst_storage\` volume was untouched throughout the cutover (backfill is read-only on the source), so every pre-cutover blob is still on disk and renders normally after this deploys.

## Note on the 2 ghost blobs

Pre-rollback \`service_name\` distribution was \`{"seaweedfs" => 385}\`, not 383. The 2 extra rows are from your failed Direct Upload attempts during the broken cutover window — DB rows exist but no bytes anywhere (neither local nor SeaweedFS). They'll show as broken images. I'll clean those up after the rollback deploys.

## Next: the proper fix

Expose SeaweedFS S3 at a public HTTPS subdomain via \`kamal-proxy\` (e.g., \`https://storage.workeverywhere.app\`), wire CORS for that origin, then redo the cutover (same backfill+verify+promote+flip dance, idempotent). Tracking as a fresh subtask of #44.

\`Refs #44\`.