### PR TITLE
Remove unused :mirror service block (#44 cleanup)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # available as a rollback surface — every pre-cutover blob is
   # still on disk, untouched by the backfill (which was read-only
   # on the source). Rollback: rake seaweedfs:demote_service_names
-  # (instant) + revert this to :mirror or :local, redeploy.
+  # (instant) + revert this to :local, redeploy.
   config.active_storage.service = :seaweedfs
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -49,15 +49,3 @@ seaweedfs:
   # ETag = MD5 server-side); only the SDK-side trailer is skipped.
   request_checksum_calculation: when_required
   response_checksum_validation: when_required
-
-# Dual-write window for the #44 prod cutover. With production.rb set to
-# :mirror, new uploads write to BOTH :local (primary) and :seaweedfs;
-# reads come from :local — so the app keeps serving existing blobs
-# unchanged while new ones land on both stores. Combined with
-# `rake seaweedfs:backfill` for existing blobs, this is the zero-loss
-# path to the final :seaweedfs cutover.
-mirror:
-  service: Mirror
-  primary: local
-  mirrors:
-    - seaweedfs


### PR DESCRIPTION
Post-#44 cleanup. The `:mirror` Active Storage service was the dual-write scaffold for the prod cutover; after Phase 2 (#167/#168/#169) it's been unused. This PR removes the block from `config/storage.yml` and drops the `:mirror` rollback option from the `production.rb` comment — rollback is now just `rake seaweedfs:demote_service_names` + revert `production.rb` to `:local` + redeploy.

`lib/tasks/seaweedfs.rake` keeps the `IN ('local', 'mirror')` guard in `promote_service_names` — harmless, defensive against any future re-introduction.

## Validation

- `bundle exec rake project:lint`: 509/0
- `bundle exec rake project:tests`: 781/0 (+2 pre-existing pendings)

`Refs #44`.