### PR TITLE
Default the MCP agent + SKILL to Direct Upload for media (#172 follow-up)

### DIFF
--- a/.claude/skills/trip-journal-mcp/SKILL.md
+++ b/.claude/skills/trip-journal-mcp/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: trip-journal-mcp
-description: Connect to and operate the Trip Journal MCP server as Jack, the AI travel assistant. Use when the user asks to interact with trips, journal entries, images, comments, reactions, or checklists through the MCP endpoint -- or when configuring an MCP client (Claude Desktop, Cursor, etc.) to connect to this service. Covers all 23 tools, authentication, input validation, trip state constraints, and common workflows.
+description: Connect to and operate the Trip Journal MCP server as Jack, the AI travel assistant. Use when the user asks to interact with trips, journal entries, images, videos, comments, reactions, or checklists through the MCP endpoint -- or when configuring an MCP client (Claude Desktop, Cursor, etc.) to connect to this service. Covers all 27 tools (including the Direct Upload pair for media), authentication, input validation, trip state constraints, and common workflows.
 compatibility: Requires a running Trip Journal instance with MCP_API_KEY configured
 metadata:
   author: joel
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Trip Journal MCP Server
 
-You are connecting to the Trip Journal MCP server as **Jack**, an AI travel assistant. Jack can create and manage journal entries, attach images via URLs or upload them directly as base64-encoded data, add comments and reactions, update trip details, transition trip states, toggle checklist items, and query trip status.
+You are connecting to the Trip Journal MCP server as **Jack**, an AI travel assistant. Jack can create and manage journal entries, attach images and videos (Direct Upload to SeaweedFS is the default; URL and base64 paths are kept as fallbacks), add comments and reactions, update trip details, transition trip states, toggle checklist items, and query trip status.
 
 ## Connection
 
@@ -57,19 +57,62 @@ Two layers:
 | `list_journal_entries` | List entries with pagination | (none) | `trip_id`, `limit` (1-100, default 10), `offset` (>= 0) |
 | `get_journal_entry` | Get one entry: HTML body, counts, image URLs | `journal_entry_id` | (none) |
 
-### Images
+### Images and Videos — **Direct Upload is the default**
+
+Bytes go **agent → SeaweedFS** directly (no Rails on the byte path), then a tiny JSON-RPC call attaches by `signed_id`. This is the only path that handles 1 GB videos and avoids the JSON-RPC base64 inflation tax. URL and base64 paths exist only as fallbacks.
 
 | Tool | Description | Required | Optional |
 |------|-------------|----------|----------|
-| `add_journal_images` | Attach images via HTTPS URLs | `journal_entry_id`, `urls` (array, max 5) | (none) |
-| `upload_journal_images` | Upload images via base64-encoded data | `journal_entry_id`, `images` (array of `{data, filename?}`, max 5) | (none) |
+| `prepare_journal_image_upload` | **Step 1 (images)** — returns `{signed_id, put_url, headers, expires_at}` for a presigned PUT. Caps: jpeg/png/webp/gif, max **50 MB**. | `journal_entry_id`, `filename`, `content_type`, `byte_size`, `checksum` | (none) |
+| `prepare_journal_video_upload` | **Step 1 (videos)** — same shape. Caps: mp4/quicktime/webm, max **1 GB**. | `journal_entry_id`, `filename`, `content_type`, `byte_size`, `checksum` | (none) |
+| `add_journal_images` | **Step 3 (images)** — attach via `signed_ids` (preferred) **or** HTTPS `urls` fallback. | `journal_entry_id` + exactly one of `signed_ids` / `urls` | (none) |
+| `add_journal_videos` | **Step 3 (videos)** — same shape. | `journal_entry_id` + exactly one of `signed_ids` / `urls` | (none) |
+| `upload_journal_images` | Fallback: base64 inline (max 5, 10 MB each). | `journal_entry_id`, `images` (array of `{data, filename?}`) | (none) |
+| `upload_journal_videos` | Fallback: base64 inline for short clips (max 2, 50 MB each). | `journal_entry_id`, `videos` (array of `{data, filename?}`) | (none) |
 
-Image constraints: max 5 images per call, max 10 MB per image, max 20 images per entry. Allowed content types: `image/jpeg`, `image/png`, `image/webp`, `image/gif`.
+#### The 3-step Direct Upload flow
 
-- **`add_journal_images`**: Downloads from HTTPS URLs with pinned DNS resolution and SSRF protection (internal/private IPs blocked). All-or-nothing -- if any URL fails, no images are attached.
-- **`upload_journal_images`**: Accepts base64-encoded image data inline. Content type is detected from actual bytes via Marcel (caller-declared type is ignored). Rejects oversized payloads before decoding. Optional `filename` per image; defaults to `image_N.<ext>` based on detected MIME.
+```
+# 1. Prepare (server creates the blob row + presigned PUT URL)
+POST /mcp  tools/call  prepare_journal_video_upload
+  { journal_entry_id, filename, content_type, byte_size, checksum }
+# -> { signed_id, put_url, headers: {...}, expires_at }
 
-Both tools emit the same `journal_entry.images_added` event and reuse the same downstream subscriber/job pipeline.
+# 2. PUT bytes straight to SeaweedFS (no Rails on this hop)
+curl -X PUT "<put_url>" \
+     -H "Content-Type: video/mp4" \
+     -H "Content-MD5: <checksum>" \
+     --data-binary @clip.mp4
+
+# 3. Attach (server validates blob metadata + writability, then attaches)
+POST /mcp  tools/call  add_journal_videos
+  { journal_entry_id, signed_ids: ["<signed_id>"] }
+# -> { attached, total_videos }
+```
+
+`checksum` is the **base64-encoded MD5** of the bytes; the server signs it into the PUT URL as `Content-MD5`, so the bytes you PUT must match. Presigned URLs and signed_ids expire in 10 minutes. Unattached blobs (you never get to step 3) are reaped by `OrphanBlobsCleanupJob` after 24h, so abandoning a prepare is safe.
+
+#### Caps & guards
+
+| | Image | Video |
+|---|---|---|
+| Allowed content types | jpeg, png, webp, gif | mp4, quicktime, webm |
+| Per-blob size (Direct Upload) | 50 MB | 1 GB |
+| Per-entry total | 20 | 5 |
+| Per-call (signed_ids) | 5 | 5 |
+| URL fallback size cap | 10 MB | 200 MB |
+| Base64 fallback size cap | 10 MB | 50 MB |
+
+#### Fallback paths (only when Direct Upload isn't possible)
+
+- **`add_journal_images(urls:)` / `add_journal_videos(urls:)`** — server downloads from HTTPS URLs with pinned DNS resolution and SSRF protection (internal/private IPs blocked). All-or-nothing — if any URL fails, none are attached. Use for content already hosted on a public HTTPS URL.
+- **`upload_journal_images(images:)` / `upload_journal_videos(videos:)`** — base64 inline in the JSON-RPC payload. Use only for small one-off snippets. The base64 inflation makes anything more than a few MB unwieldy.
+
+`urls` and `signed_ids` on `add_journal_*` are **mutually exclusive** — pass exactly one; the tool errors if both or neither are provided.
+
+#### Events + transcoding
+
+All three image paths emit `journal_entry.images_added`; all three video paths emit `journal_entry.videos_added`. Videos are transcoded to a ≤720p H.264/AAC rendition + poster by `ProcessJournalVideosJob` asynchronously after attach — they start in the `pending` status and the gallery only shows them once `ready`.
 
 ### Social
 
@@ -151,7 +194,7 @@ Tools enforce state constraints. Calling a tool on an incompatible trip state re
 
 | Guard | Allowed states | Tools |
 |-------|---------------|-------|
-| `writable` | planning, started | create/update/delete journal entry, add/upload images, update trip, toggle checklist, update/delete comment, create/update/delete checklist, create checklist item |
+| `writable` | planning, started | create/update/delete journal entry, prepare/add/upload images, prepare/add/upload videos, update trip, toggle checklist, update/delete comment, create/update/delete checklist, create checklist item |
 | `commentable` | planning, started, finished | create comment, add reaction |
 
 Read-only tools (`get_journal_entry`, `list_comments`, `list_reactions`, `list_trips`) have no state guard.
@@ -192,30 +235,75 @@ Error messages are actionable:
 4. add_reaction(journal_entry_id: "<id>", emoji: "fire")
 ```
 
-### Attach photos to a journal entry
+### Attach photos to a journal entry (**Direct Upload — default**)
 
 ```
 1. list_journal_entries(limit: 1)            # Find the latest entry
-2. add_journal_images(
+
+2. # For each image, prepare the upload:
+   prepare_journal_image_upload(
      journal_entry_id: "<id>",
-     urls: [
-       "https://cdn.example.com/photo1.jpg",
-       "https://cdn.example.com/photo2.jpg"
-     ]
+     filename: "sunset.jpg",
+     content_type: "image/jpeg",
+     byte_size: 2_847_193,
+     checksum: "<base64-md5>"
+   )
+   # -> { signed_id, put_url, headers, expires_at }
+
+3. # PUT the raw bytes (one HTTP PUT per image, in parallel)
+   PUT <put_url>
+     Content-Type: image/jpeg
+     Content-MD5: <checksum>
+     body: <raw bytes>
+
+4. # Attach them all at once with the signed_ids:
+   add_journal_images(
+     journal_entry_id: "<id>",
+     signed_ids: ["<signed_id_1>", "<signed_id_2>"]
    )
 ```
 
-### Upload photos directly (no external hosting)
+### Attach a video to a journal entry (**Direct Upload — default**)
+
+Same shape as images, but use `prepare_journal_video_upload` and `add_journal_videos`. Caps: mp4/quicktime/webm, 1 GB. Videos are transcoded asynchronously to a ≤720p rendition + poster after attach; status starts at `pending` and becomes `ready` when the job finishes.
 
 ```
-1. list_journal_entries(limit: 1)            # Find the latest entry
-2. upload_journal_images(
-     journal_entry_id: "<id>",
-     images: [
-       { data: "<base64-encoded-jpeg>", filename: "sunset.jpg" },
-       { data: "<base64-encoded-png>" }
-     ]
-   )
+prepare_journal_video_upload(
+  journal_entry_id: "<id>",
+  filename: "valencia-evening.mp4",
+  content_type: "video/mp4",
+  byte_size: 84_900_000,
+  checksum: "<base64-md5>"
+)
+# -> PUT bytes to put_url -> add_journal_videos(signed_ids: [...])
+```
+
+### Fallback: attach via HTTPS URL (already-hosted source)
+
+Use only when the media is already on a public HTTPS URL and Direct Upload isn't worth setting up.
+
+```
+add_journal_images(
+  journal_entry_id: "<id>",
+  urls: [
+    "https://cdn.example.com/photo1.jpg",
+    "https://cdn.example.com/photo2.jpg"
+  ]
+)
+```
+
+### Fallback: attach via base64 inline (tiny clips only)
+
+Use only for snippets small enough that base64 inflation doesn't matter (a few MB at most). For anything larger, Direct Upload is the right path.
+
+```
+upload_journal_images(
+  journal_entry_id: "<id>",
+  images: [
+    { data: "<base64-encoded-jpeg>", filename: "sunset.jpg" },
+    { data: "<base64-encoded-png>" }
+  ]
+)
 ```
 
 ### Add commentary to an existing entry
@@ -250,6 +338,11 @@ Trip (state machine: planning/started/finished/cancelled/archived)
   |-- has_many :journal_entries
   |     |-- has_rich_text :body (HTML)
   |     |-- has_many_attached :images (Active Storage)
+  |     |-- has_many :videos -> JournalEntryVideo
+  |     |     |-- has_one_attached :source (original)
+  |     |     |-- has_one_attached :web (≤720p transcode)
+  |     |     |-- has_one_attached :poster (thumbnail)
+  |     |     |-- status: pending -> ready (after ProcessJournalVideosJob)
   |     |-- has_many :comments
   |     |-- has_many :reactions (polymorphic)
   |

--- a/app/mcp/README.md
+++ b/app/mcp/README.md
@@ -27,7 +27,7 @@ The Model Context Protocol (MCP) server exposes trip journaling capabilities to 
        | require_writable!, require_commentable!
        | success_response / error_response
        v
-  25 MCP Tools  -->  Actions (Dry::Monads)  -->  ActiveRecord
+  27 MCP Tools  -->  Actions (Dry::Monads)  -->  ActiveRecord
 ```
 
 ## Endpoint

--- a/app/mcp/trip_journal_server.rb
+++ b/app/mcp/trip_journal_server.rb
@@ -42,7 +42,7 @@ class TripJournalServer
     )
   end
 
-  def self.instructions_for(agent)
+  def self.instructions_for(agent) # rubocop:disable Metrics/MethodLength -- one-shot prompt string for the agent
     persona =
       if agent
         "You are #{agent.name}, an AI travel assistant"
@@ -51,20 +51,33 @@ class TripJournalServer
       end
     <<~TEXT
       #{persona} for the Trip Journal app.
+
       You can create, edit, and delete journal entries; attach images
-      and videos to them (the recommended flow is the Direct Upload
-      pair: prepare_journal_image_upload / prepare_journal_video_upload
-      to get a presigned PUT URL, then add_journal_images /
-      add_journal_videos with the returned signed_ids — both tools
-      also accept urls or base64 as fallback paths, videos are
-      transcoded asynchronously); add and
-      remove emoji reactions; write, edit, and delete comments; create,
-      rename, and delete checklists and add items to them; update trip
-      details; transition trip states; and query trip status, entries,
-      comments, reactions, and the trip list. When no trip_id is
-      provided, you operate on the single currently active (started)
-      trip. Trip creation and member administration are handled by
-      humans.
+      and videos; add and remove emoji reactions; write, edit, and
+      delete comments; create, rename, and delete checklists and add
+      items to them; update trip details; transition trip states; and
+      query trip status, entries, comments, reactions, and the trip
+      list.
+
+      **Media uploads: ALWAYS use Direct Upload by default.** It is
+      the only path that supports 1GB videos and avoids inflating the
+      MCP request with base64. Three-step flow:
+
+        1. prepare_journal_image_upload / prepare_journal_video_upload
+           — server returns {signed_id, put_url, headers, expires_at}.
+        2. HTTP PUT the raw bytes to put_url with the returned
+           headers (Content-Type + Content-MD5). Direct to SeaweedFS.
+        3. add_journal_images / add_journal_videos with
+           {journal_entry_id, signed_ids: [...]}.
+
+      The urls and base64 paths on add/upload_journal_* exist only as
+      fallbacks for cases where HTTP PUT isn't possible (small inline
+      snippets or already-hosted HTTPS sources). Default to Direct
+      Upload. Videos are transcoded asynchronously after attach.
+
+      When no trip_id is provided, you operate on the single
+      currently active (started) trip. Trip creation and member
+      administration are handled by humans.
     TEXT
   end
 end

--- a/spec/mcp/trip_journal_server_spec.rb
+++ b/spec/mcp/trip_journal_server_spec.rb
@@ -67,5 +67,15 @@ RSpec.describe TripJournalServer do
         .to include("Trip creation and member administration are " \
                     "handled by humans")
     end
+
+    it "tells agents to default to Direct Upload for media (#172)" do
+      text = described_class.instructions_for(nil).gsub(/\s+/, " ")
+
+      expect(text).to include("ALWAYS use Direct Upload by default")
+      expect(text).to include("prepare_journal_image_upload")
+      expect(text).to include("prepare_journal_video_upload")
+      expect(text).to include("signed_ids")
+      expect(text).to include("fallbacks")
+    end
   end
 end


### PR DESCRIPTION
Small follow-up to #172. Now that the Direct Upload pair is live in production and the live smoke is clean, point both the MCP server's agent prompt and the local SKILL at it as the default.

\`Refs #172\`.

## Changes

- \`app/mcp/trip_journal_server.rb\` — \`instructions_for\` rewritten. The agent prompt now leads with the 3-step Direct Upload flow (\`prepare_*\` → PUT to \`put_url\` → \`add_*\` with \`signed_ids\`) as the default, and explicitly frames urls/base64 as fallbacks.
- \`spec/mcp/trip_journal_server_spec.rb\` — locked the new guidance in (\"ALWAYS use Direct Upload\", both prepare tool names, signed_ids, fallbacks).
- \`.claude/skills/trip-journal-mcp/SKILL.md\` — rewrote the Images section as \"Images and Videos — Direct Upload is the default\", added the videos table row that was missing, replaced the URL/base64 workflow examples with a 3-step Direct Upload walkthrough, refreshed the caps table, updated the writable-guard list, and added JournalEntryVideo to the domain model. Frontmatter bumped to 27 tools / v1.1.
- \`app/mcp/README.md\` — corrected the tool count (25 → 27).

## Validation

- \`bundle exec rubocop app/mcp/trip_journal_server.rb spec/mcp/trip_journal_server_spec.rb\`: clean.
- \`bundle exec rspec spec/mcp/trip_journal_server_spec.rb\`: 6/0 (including the new assertion).