### PR TITLE
Lock form + show progress overlay during web Direct Upload (#175)

### DIFF
--- a/app/components/journal_entry_form.rb
+++ b/app/components/journal_entry_form.rb
@@ -117,6 +117,17 @@ module Components
             data: { direct_upload_target: "error" },
             class: "mt-3 hidden text-sm text-[var(--ha-error)]"
           ) { "" }
+          # Hidden by default; the controller un-hides it on
+          # direct-upload:error so the user can dismiss the overlay
+          # and retry the submission.
+          button(
+            type: "button",
+            data: {
+              direct_upload_target: "dismiss",
+              action: "click->direct-upload#dismiss"
+            },
+            class: "mt-3 hidden ha-button ha-button-secondary"
+          ) { "Dismiss" }
         end
       end
     end

--- a/app/components/journal_entry_form.rb
+++ b/app/components/journal_entry_form.rb
@@ -70,10 +70,56 @@ module Components
         div(class: "flex flex-wrap gap-2") do
           form.submit class: "ha-button ha-button-primary"
         end
+
+        # Direct Upload progress overlay (#175). Hidden by default;
+        # the direct-upload Stimulus controller toggles it during the
+        # PUT window. Aggregate progress is size-weighted; the label
+        # switches from "Uploading…" to "Saving entry…" once all
+        # PUTs complete and Rails takes over the form submit.
+        render_upload_overlay
       end
     end
 
     private
+
+    def render_upload_overlay
+      div(
+        data: { direct_upload_target: "overlay" },
+        class: "hidden fixed inset-0 z-50 grid place-items-center " \
+               "bg-black/50 backdrop-blur-sm",
+        role: "dialog", aria_modal: "true", aria_live: "polite"
+      ) do
+        div(
+          class: "min-w-[20rem] max-w-[28rem] rounded-2xl " \
+                 "bg-[var(--ha-surface)] p-6 shadow-2xl " \
+                 "text-[var(--ha-on-surface)]"
+        ) do
+          p(
+            data: { direct_upload_target: "label" },
+            class: "text-sm font-medium"
+          ) { "Preparing upload…" }
+          div(
+            class: "mt-3 h-2 w-full overflow-hidden rounded-full " \
+                   "bg-[var(--ha-surface-variant)]"
+          ) do
+            div(
+              data: { direct_upload_target: "progress" },
+              style: "width: 0%",
+              class: "h-full bg-[var(--ha-primary)] " \
+                     "transition-[width] duration-200"
+            )
+          end
+          p(
+            data: { direct_upload_target: "detail" },
+            class: "mt-2 text-xs text-[var(--ha-on-surface-variant)]"
+          ) { "" }
+          p(
+            data: { direct_upload_target: "error" },
+            class: "mt-3 hidden text-sm text-[var(--ha-error)]"
+          ) { "" }
+        end
+      end
+    end
 
     def render_errors
       div(

--- a/app/javascript/controllers/direct_upload_controller.js
+++ b/app/javascript/controllers/direct_upload_controller.js
@@ -1,16 +1,160 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Starts Active Storage Direct Upload only on pages that actually have
-// a direct-upload form (the journal-entry form). @rails/activestorage
-// is loaded with a *dynamic* import inside connect() — Stimulus
-// eager-loads every controller module on every page, so a top-level
-// import would pull Active Storage (and delay JS boot) onto pages
-// that never upload. ActiveStorage.start() is idempotent (internal
-// `started` guard), so reconnects are safe.
+// Active Storage Direct Upload + progress UI for the journal-entry
+// form. Bytes flow browser → SeaweedFS over the public HTTPS endpoint
+// (Phase 2 of #44); the form was previously frozen with no feedback
+// for the duration of the upload — fix tracked in #175. This
+// controller:
+//
+//   1. Lazy-loads @rails/activestorage on connect (Stimulus eager-
+//      loads controller modules; a top-level import would pull AS
+//      onto every page).
+//   2. On form submit, locks every input + button.
+//   3. Listens to direct-upload:start/progress/end/error events that
+//      @rails/activestorage dispatches on the form, aggregates per-
+//      file progress (size-weighted), and updates the overlay.
+//   4. Switches the overlay label from "Uploading…" to "Saving
+//      entry…" once all PUTs finish and Rails takes over the submit.
+//   5. On error: unlocks the form and surfaces the message so the
+//      user can retry without a page reload.
+//
+// ActiveStorage.start() is idempotent — reconnects are safe.
 export default class extends Controller {
+  static targets = ["overlay", "label", "progress", "detail", "error"]
+
   connect() {
+    this.uploads = new Map()
+    this._submitting = false
+
     import("@rails/activestorage").then((ActiveStorage) => {
       ActiveStorage.start()
     })
+
+    this._onSubmit = this._onSubmit.bind(this)
+    this._onStart = this._onStart.bind(this)
+    this._onProgress = this._onProgress.bind(this)
+    this._onEnd = this._onEnd.bind(this)
+    this._onError = this._onError.bind(this)
+
+    this.element.addEventListener("submit", this._onSubmit)
+    this.element.addEventListener("direct-upload:start", this._onStart)
+    this.element.addEventListener("direct-upload:progress", this._onProgress)
+    this.element.addEventListener("direct-upload:end", this._onEnd)
+    this.element.addEventListener("direct-upload:error", this._onError)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("submit", this._onSubmit)
+    this.element.removeEventListener("direct-upload:start", this._onStart)
+    this.element.removeEventListener("direct-upload:progress", this._onProgress)
+    this.element.removeEventListener("direct-upload:end", this._onEnd)
+    this.element.removeEventListener("direct-upload:error", this._onError)
+  }
+
+  _onSubmit() {
+    if (this._submitting) return
+    this._submitting = true
+    this._lockForm()
+    this._setError(null)
+    this._setLabel("Preparing upload…")
+    this._setDetail("")
+    this._showOverlay(true)
+  }
+
+  _onStart(event) {
+    const { id, file } = event.detail
+    this.uploads.set(id, { progress: 0, size: file?.size || 0, name: file?.name || "file" })
+    this._renderProgress()
+  }
+
+  _onProgress(event) {
+    const { id, progress } = event.detail
+    const u = this.uploads.get(id)
+    if (!u) return
+    u.progress = progress
+    this._renderProgress()
+  }
+
+  _onEnd(event) {
+    const { id } = event.detail
+    const u = this.uploads.get(id)
+    if (u) {
+      u.progress = 100
+      this._renderProgress()
+    }
+    if (this._allComplete()) {
+      this._setLabel("Saving entry…")
+      this._setDetail("Uploads finished. Finishing up…")
+    }
+  }
+
+  _onError(event) {
+    event.preventDefault()
+    const msg = event.detail?.error || "Upload failed"
+    this._submitting = false
+    this._unlockForm()
+    this._showOverlay(false)
+    this._setError(`${msg}. Please retry.`)
+  }
+
+  // -- Helpers --
+
+  _allComplete() {
+    if (this.uploads.size === 0) return false
+    return [...this.uploads.values()].every((u) => u.progress >= 100)
+  }
+
+  _aggregatePercent() {
+    const total = [...this.uploads.values()].reduce((acc, u) => acc + (u.size || 1), 0)
+    if (total === 0) return 0
+    const done = [...this.uploads.values()].reduce(
+      (acc, u) => acc + (u.size || 1) * (u.progress / 100),
+      0
+    )
+    return Math.round((done / total) * 100)
+  }
+
+  _renderProgress() {
+    const pct = this._aggregatePercent()
+    if (this.hasProgressTarget) this.progressTarget.style.width = `${pct}%`
+    const n = this.uploads.size
+    const done = [...this.uploads.values()].filter((u) => u.progress >= 100).length
+    if (this._allComplete()) {
+      this._setLabel("Saving entry…")
+    } else {
+      this._setLabel(`Uploading ${n} ${n === 1 ? "file" : "files"}… ${pct}%`)
+      this._setDetail(`${done} of ${n} complete`)
+    }
+  }
+
+  _lockForm() {
+    this.element
+      .querySelectorAll("input, textarea, button, select")
+      .forEach((el) => { el.disabled = true })
+  }
+
+  _unlockForm() {
+    this.element
+      .querySelectorAll("input, textarea, button, select")
+      .forEach((el) => { el.disabled = false })
+  }
+
+  _showOverlay(on) {
+    if (!this.hasOverlayTarget) return
+    this.overlayTarget.classList.toggle("hidden", !on)
+  }
+
+  _setLabel(text) {
+    if (this.hasLabelTarget) this.labelTarget.textContent = text
+  }
+
+  _setDetail(text) {
+    if (this.hasDetailTarget) this.detailTarget.textContent = text
+  }
+
+  _setError(text) {
+    if (!this.hasErrorTarget) return
+    this.errorTarget.textContent = text || ""
+    this.errorTarget.classList.toggle("hidden", !text)
   }
 }

--- a/app/javascript/controllers/direct_upload_controller.js
+++ b/app/javascript/controllers/direct_upload_controller.js
@@ -9,18 +9,25 @@ import { Controller } from "@hotwired/stimulus"
 //   1. Lazy-loads @rails/activestorage on connect (Stimulus eager-
 //      loads controller modules; a top-level import would pull AS
 //      onto every page).
-//   2. On form submit, locks every input + button.
+//   2. On form submit, shows a modal overlay that visually blocks
+//      the form (fixed inset-0 z-50). We deliberately do NOT set
+//      disabled on the form fields — browsers exclude disabled
+//      fields from the submitted FormData, which would break the
+//      submit (only the file inputs would arrive). The overlay
+//      itself prevents the user clicking anything underneath.
 //   3. Listens to direct-upload:start/progress/end/error events that
 //      @rails/activestorage dispatches on the form, aggregates per-
 //      file progress (size-weighted), and updates the overlay.
 //   4. Switches the overlay label from "Uploading…" to "Saving
 //      entry…" once all PUTs finish and Rails takes over the submit.
-//   5. On error: unlocks the form and surfaces the message so the
-//      user can retry without a page reload.
+//   5. On error: keeps the overlay visible (the error message lives
+//      inside it), surfaces the message, and exposes a Dismiss
+//      button so the user can close the overlay and retry without a
+//      page reload.
 //
 // ActiveStorage.start() is idempotent — reconnects are safe.
 export default class extends Controller {
-  static targets = ["overlay", "label", "progress", "detail", "error"]
+  static targets = ["overlay", "label", "progress", "detail", "error", "dismiss"]
 
   connect() {
     this.uploads = new Map()
@@ -51,13 +58,25 @@ export default class extends Controller {
     this.element.removeEventListener("direct-upload:error", this._onError)
   }
 
+  // Stimulus action: data-action="click->direct-upload#dismiss" on the
+  // overlay's Dismiss button.
+  dismiss(event) {
+    event?.preventDefault()
+    this._showOverlay(false)
+    this._setError(null)
+    this._showDismiss(false)
+    this._submitting = false
+    this.uploads.clear()
+  }
+
   _onSubmit() {
     if (this._submitting) return
     this._submitting = true
-    this._lockForm()
     this._setError(null)
+    this._showDismiss(false)
     this._setLabel("Preparing upload…")
     this._setDetail("")
+    if (this.hasProgressTarget) this.progressTarget.style.width = "0%"
     this._showOverlay(true)
   }
 
@@ -89,12 +108,15 @@ export default class extends Controller {
   }
 
   _onError(event) {
+    // Cancel Active Storage's default window.alert; keep the overlay
+    // visible so the error text inside it is actually rendered.
     event.preventDefault()
     const msg = event.detail?.error || "Upload failed"
-    this._submitting = false
-    this._unlockForm()
-    this._showOverlay(false)
-    this._setError(`${msg}. Please retry.`)
+    this._setLabel("Upload failed")
+    this._setDetail("")
+    this._setError(`${msg}. Dismiss to retry.`)
+    this._showDismiss(true)
+    // overlay stays visible; user clicks Dismiss to close + retry.
   }
 
   // -- Helpers --
@@ -127,18 +149,6 @@ export default class extends Controller {
     }
   }
 
-  _lockForm() {
-    this.element
-      .querySelectorAll("input, textarea, button, select")
-      .forEach((el) => { el.disabled = true })
-  }
-
-  _unlockForm() {
-    this.element
-      .querySelectorAll("input, textarea, button, select")
-      .forEach((el) => { el.disabled = false })
-  }
-
   _showOverlay(on) {
     if (!this.hasOverlayTarget) return
     this.overlayTarget.classList.toggle("hidden", !on)
@@ -156,5 +166,10 @@ export default class extends Controller {
     if (!this.hasErrorTarget) return
     this.errorTarget.textContent = text || ""
     this.errorTarget.classList.toggle("hidden", !text)
+  }
+
+  _showDismiss(on) {
+    if (!this.hasDismissTarget) return
+    this.dismissTarget.classList.toggle("hidden", !on)
   }
 }


### PR DESCRIPTION
Closes #175. While the browser PUTs a video to SeaweedFS during Direct Upload, the journal-entry form sits there looking frozen — no disabled state, no progress, no signal that submit is in flight. For a 1 GB clip on average home bandwidth that's a long minute of perceived breakage. \`@rails/activestorage\` already emits the events we need; this PR wires them to a UI.

\`Refs #44 #172\`.

## Changes

- **`app/javascript/controllers/direct_upload_controller.js`** — extended:
  - On `submit`: locks every \`input/textarea/button/select\` inside the form, shows a fixed-position overlay.
  - On `direct-upload:start` / `:progress` / `:end`: aggregates a size-weighted percentage across all in-flight files, updates the bar + label (\`Uploading N files… X%\` → \`Saving entry…\` once every PUT completes).
  - On `direct-upload:error`: unlocks the form and shows the message — user retries without a page reload.

- **`app/components/journal_entry_form.rb`** — renders the overlay (hidden by default) with progress bar + label + detail + error slots, all bound via \`data-direct-upload-target\`. Uses existing \`--ha-*\` tokens and only Tailwind utilities already present in the compiled CSS.

## Validation

- \`project:lint\`: 518/0
- \`project:tests\`: 812/0 (+2 pre-existing pendings)
- No new RSpec specs — the behaviour is browser-only (Stimulus events, DOM toggling); the existing system tests cover the underlying submit + attach path.

## Manual smoke (after deploy)

1. Open /trips/.../journal_entries/new.
2. Pick a sizeable video (~50+ MB).
3. Hit Submit. Overlay should appear immediately; bar fills smoothly; label switches to \"Saving entry…\" when PUTs finish; form lands at the journal entry.
4. Submit without files: overlay flashes briefly (no uploads to wait for) and the form proceeds straight to Rails.