### PR TITLE
Auto-replace video placeholder when transcoding finishes (#177)

### DIFF
--- a/app/components/journal_entry_card.rb
+++ b/app/components/journal_entry_card.rb
@@ -5,6 +5,7 @@ module Components
     include Phlex::Rails::Helpers::LinkTo
     include Phlex::Rails::Helpers::ButtonTo
     include Phlex::Rails::Helpers::DOMID
+    include Phlex::Rails::Helpers::TurboStreamFrom
     include ImageLightbox
 
     def initialize(trip:, journal_entry:)
@@ -142,6 +143,10 @@ module Components
 
     def render_videos
       div(class: "space-y-4 mb-6") do
+        # Live-update each VideoPlayer when transcoding flips its
+        # status (#177). The cable channel is per-entry so a card
+        # only receives updates for its own videos.
+        turbo_stream_from @entry, :videos if @entry.videos.any?
         @entry.videos.each do |video|
           render Components::VideoPlayer.new(video: video)
         end

--- a/app/components/video_player.rb
+++ b/app/components/video_player.rb
@@ -15,10 +15,15 @@ module Components
     end
 
     def view_template
-      case @video.status.to_s
-      when "ready" then render_player
-      when "failed" then render_unavailable
-      else render_processing
+      # Stable wrapper id so the JournalEntryVideo after_update_commit
+      # broadcast (#177) can `replace` this element when transcoding
+      # finishes. id == "journal_entry_video_<uuid>".
+      div(id: ActionView::RecordIdentifier.dom_id(@video)) do
+        case @video.status.to_s
+        when "ready" then render_player
+        when "failed" then render_unavailable
+        else render_processing
+        end
       end
     end
 

--- a/app/models/journal_entry_video.rb
+++ b/app/models/journal_entry_video.rb
@@ -16,4 +16,29 @@ class JournalEntryVideo < ApplicationRecord
        default: :pending
 
   scope :ready, -> { where(status: :ready) }
+
+  # When the transcoding job flips status (pending → ready / failed),
+  # push a Turbo Stream that replaces the placeholder with the right
+  # VideoPlayer rendering on every open viewer of the journal entry —
+  # no manual refresh (#177). Subscribers are added by
+  # JournalEntryCard's `turbo_stream_from @entry, :videos`. The Phlex
+  # component is rendered via ApplicationController.render so url_for
+  # + routes work outside a request cycle.
+  after_update_commit :broadcast_status_change, if: :saved_change_to_status?
+
+  private
+
+  def broadcast_status_change
+    # layout: false — render just the component, not the full app
+    # layout (which expects a current_user context that doesn't
+    # exist in the after_update_commit callback chain).
+    html = ApplicationController.render(
+      Components::VideoPlayer.new(video: self), layout: false
+    )
+    Turbo::StreamsChannel.broadcast_replace_to(
+      journal_entry, :videos,
+      target: ActionView::RecordIdentifier.dom_id(self),
+      html: html
+    )
+  end
 end

--- a/spec/models/journal_entry_video_spec.rb
+++ b/spec/models/journal_entry_video_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe JournalEntryVideo do
+  describe "Turbo Stream broadcast on status change (#177)" do
+    let(:video) { create(:journal_entry_video, :ready) }
+
+    before { allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to) }
+
+    it "broadcasts a replace targeting the video's dom_id when status changes" do
+      # The :ready factory built the row at status: :ready already;
+      # transition to :failed so we exercise the after_update_commit.
+      video.update!(status: :failed)
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_replace_to)
+        .with(video.journal_entry, :videos,
+              hash_including(target: ActionView::RecordIdentifier.dom_id(video)))
+    end
+
+    it "does not broadcast when something other than status changes" do
+      video.update!(position: video.position + 1)
+      expect(Turbo::StreamsChannel).not_to have_received(:broadcast_replace_to)
+    end
+  end
+end


### PR DESCRIPTION
Closes #177. Adds a Turbo Stream broadcast on \`JournalEntryVideo\` status changes so the \"Optimizing video…\" placeholder is replaced with the actual \`<video>\` player automatically — no manual refresh.

\`Refs #44 #175\`.

## Wiring

| File | Change |
|------|--------|
| \`app/components/video_player.rb\` | Wrap all three branches (ready / processing / failed) in an outer div with a stable \`dom_id\` so Turbo \`replace\` has a target. |
| \`app/components/journal_entry_card.rb\` | \`turbo_stream_from [@entry, :videos]\` inside \`render_videos\` (only when the entry has videos). Adds \`Phlex::Rails::Helpers::TurboStreamFrom\`. |
| \`app/models/journal_entry_video.rb\` | \`after_update_commit\` when \`saved_change_to_status?\` broadcasts a \`turbo-stream action=replace\` targeting the video's \`dom_id\` with the freshly-rendered Phlex \`VideoPlayer\` (via \`ApplicationController.render layout: false\`). |
| \`spec/models/journal_entry_video_spec.rb\` | Asserts the broadcast fires on status change + stays quiet on other-attribute updates. |

The same broadcast also covers the \`pending → failed\` transition (swaps to the \"Video unavailable\" notice).

## Validation

- \`project:lint\`: 518/0
- \`project:tests\`: 814/0 (+2 pre-existing pendings)

## Manual smoke

1. Upload a video on a journal entry.
2. Watch the placeholder appear ("Optimizing video…").
3. Without touching the browser, wait for \`ProcessJournalVideosJob\` to finish; the placeholder should swap to the \`<video>\` player live.

## Out of scope

- Trip gallery auto-add (the gallery only renders \`ready\` videos already).
- Per-frame transcoding progress.