### PR TITLE
Add explicit ruby-vips dependency for image_processing 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,9 @@ gem "kamal", require: false
 gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 2.0"
+# Required by ImageProcessing::Vips since image_processing 2.0 dropped it as a hard dependency
+gem "ruby-vips", "~> 2.0"
 
 # S3-compatible Active Storage service for SeaweedFS (config/storage.yml)
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,9 +216,7 @@ GEM
       logger
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.0.1)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -265,8 +263,6 @@ GEM
     mcp (0.17.0)
       json-schema (>= 4.1)
     memory_profiler (1.1.0)
-    mini_magick (5.3.1)
-      logger
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -634,7 +630,7 @@ DEPENDENCIES
   flamegraph
   foreman (~> 0.90.0)
   gepub (~> 2.0)
-  image_processing (~> 1.2)
+  image_processing (~> 2.0)
   importmap-rails
   kamal
   mcp (~> 0.17)
@@ -660,6 +656,7 @@ DEPENDENCIES
   rubocop-rake
   rubocop-rspec
   rubocop-rspec_rails
+  ruby-vips (~> 2.0)
   rubyzip
   selenium-webdriver
   sequel-activerecord_connection
@@ -712,7 +709,6 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.1.2) sha256=67031a0d71d2b00ef1d6ed17903064d79e56bf2cddb4d4e2c54cd464c6b2b8c9
   bundle-audit (0.2.0) sha256=cb499708f7fbc56d2d2e8bab09a1184f8f5b548bdbd628b757e5a1856874ca12
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cbor (0.5.10.2) sha256=df5104f7a62c881123e6505441b1e276208be1771540c2cc3b1de8a210a7c52c
@@ -752,7 +748,7 @@ CHECKSUMS
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
+  image_processing (2.0.1) sha256=69c93216dafe1179343a6c3ae8bfa554e3c1f5eece4043f255595e76df2cbf3f
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
@@ -771,7 +767,6 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mcp (0.17.0) sha256=a66b71254cd8c49c471cfa55f11a9f050817ab7168cadf961555784d365b8474
   memory_profiler (1.1.0) sha256=79a17df7980a140c83c469785905409d3027ca614c42c086089d128b805aa8f8
-  mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c


### PR DESCRIPTION
## Summary

- Bump `image_processing` to `~> 2.0` and add `ruby-vips ~> 2.0` as an explicit direct dependency.
- `image_processing` 2.0 dropped `ruby-vips` as a hard runtime dependency, so bundler removed it on upgrade. Active Storage's Vips transformer then raised `ImageProcessing::Error` at variant-processing time, failing all media system specs.
- Supersedes Dependabot PR #182 (which only bumps the gem and cannot add the missing dependency).

## Test plan

- [x] All non-system specs pass (814 examples, 0 failures)
- [x] All system specs pass (93 examples, 0 failures) — the 3 previously-failing media specs (`direct_upload_spec.rb:19`, `trip_gallery_spec.rb:21`, `:44`) are green
- [x] Lint passes (rubocop + erb_lint, no offenses)
- [x] All overcommit hooks pass
- [x] Live verification: app rebuilt/restarted healthy; libvips processed real full-size and thumbnail variants inside the container; home page renders at https://catalyst.workeverywhere.docker

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)