### PR TITLE
Phase 25 — Improve Persistence: soft-delete + JournalEntry versioning

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -90,9 +90,10 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Max: 8
 
-# Offense count: 15
+# Offense count: 17
 Rails/I18nLocaleTexts:
   Exclude:
+    - 'app/controllers/audit_logs_controller.rb'
     - 'app/controllers/posts_controller.rb'
     - 'app/controllers/users_controller.rb'
     - 'app/controllers/access_requests_controller.rb'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,20 @@ Every `Rails.event` domain event is persisted as an append-only `AuditLog` row b
 
 ---
 
+## Persistence safety (Phase 25)
+
+Three complementary safety nets on the user-authored models (`Trip`, `JournalEntry`, `Comment`): **soft delete** (`discard`), **versioning** (`paper_trail`), and the **AuditLog feed** (Phase 21) which surfaces Restore/Revert. Full write-up + diagrams in [`docs/persistence-safety.md`](docs/persistence-safety.md).
+
+- **Delete means discard, not destroy.** The three `*::Delete` actions (`app/actions/{trips,journal_entries,comments}/delete.rb`) call `record.discard!`, never `destroy!`. A real `destroy` no longer fires for these models, so their `dependent: :destroy` associations (memberships, reactions, attachments) only run on an actual hard destroy — which the app no longer triggers. That is *why* restore recovers the whole graph: discard skips validations and `dependent: :destroy`, leaving the children intact.
+- **`default_scope -> { kept }` is the safety guarantee.** Each model includes `Discard::Model` and scopes to `kept`, so discarded rows never leak into any read path — views, MCP `list_*`, exports, counts, and even Rails 8.1 `left_joins` ON-clauses. **Use `with_discarded` on every restore/admin/builder path** that must see deleted rows. `discarded_at` (datetime + index) was added by `db/migrate/*_add_discarded_at_to_critical_models.rb`.
+- **`with_discarded.discarded`, never bare `.discarded`.** A bare `.discarded` self-contradicts the default scope (`discarded_at IS NULL AND IS NOT NULL` → empty). The trips trash view (`?discarded=1`) and `AuditLog::Builder` subject finders both go through `with_discarded` for exactly this reason.
+- **Cascade is down-only.** `Trip after_discard { journal_entries.kept.find_each(&:discard) }`; `JournalEntry after_discard { comments.kept.find_each(&:discard) }`. There is **no `after_undiscard`** — restore is **parent-only** by design (`*::Restore` actions call `undiscard!` and emit `*.restored`).
+- **Versioning lives in two places.** `JournalEntry` has `has_paper_trail only: %i[name]` (the **title**). The rich-text **body** is a separate `ActionText::RichText` row, versioned via `config/initializers/paper_trail_action_text.rb` — **not** a `journal_entries` column, so body edits never appear as Activity-feed column diffs (out of scope, intentional). Writes are wrapped in `PaperTrail.request(whodunnit: Current.actor&.id)` in `JournalEntries::Create`/`Update`.
+- **JSON serializer is mandatory for `reify`.** `config/initializers/paper_trail.rb` sets `PaperTrail.serializer = PaperTrail::Serializers::JSON` — Psych 4 `safe_load` rejects `ActiveSupport::TimeWithZone` on reify (`Psych::DisallowedClass`). The `versions` table is UUID-corrected (`id: :uuid`, `t.uuid :item_id`) to match the app's UUID PKs.
+- **Feed Restore vs Revert.** `AuditLogsController` computes two maps: `build_restorable` (keyed by `auditable_id`) puts a **Restore** button on `*.deleted` rows whose auditable is still discarded and whose parent chain is kept and `restore?` allows it; `build_revertable` (keyed by **audit_log id**, per-row) puts a **Revert** button on `*.updated` rows, re-applying `metadata["changes"]` olds through the record's Update action (a forward audit + version event). `restore?` was added to `Trip`/`JournalEntry`/`Comment` policies mirroring `destroy?`. Routes: `PATCH /trips/:id/{restore, activity/:id/revert}` and the nested entry/comment `restore`.
+
+---
+
 ## 5. Runtime Test Workflow (Mandatory)
 
 After all code changes are committed and tests pass, you **must** perform a live runtime verification before pushing the branch or creating a PR.

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,10 @@ gem "action_policy"
 # Business logic
 gem "dry-monads", "~> 1.10"
 
+# Persistence safety — soft-delete (discard) + record versioning (paper_trail)
+gem "discard", "~> 2.0"
+gem "paper_trail", "~> 17.0"
+
 # MCP (Model Context Protocol) server
 gem "mcp", "~> 0.17"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
+    discard (2.0.0)
+      activerecord (>= 7.0, < 9.0)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -375,6 +377,9 @@ GEM
       parser
       prism (>= 1.4.0)
       zeitwerk (>= 2.6.1)
+    paper_trail (17.0.0)
+      activerecord (>= 7.1)
+      request_store (~> 1.4)
     parallel (1.28.0)
     parse_packwerk (0.27.0)
       bigdecimal
@@ -466,6 +471,8 @@ GEM
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     reverse_markdown (3.0.2)
       nokogiri
     rexml (3.4.4)
@@ -686,6 +693,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  discard (~> 2.0)
   dotenv-rails
   dry-monads (~> 1.10)
   erb_lint
@@ -703,6 +711,7 @@ DEPENDENCIES
   overcommit
   packs-rails (~> 0.1)
   packwerk (~> 3.3)
+  paper_trail (~> 17.0)
   phlex-rails (~> 2.0)
   phlex-testing-capybara
   propshaft
@@ -793,6 +802,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  discard (2.0.0) sha256=0fc520786b4d7b9b1ea8b2b3dadbb13c3e41d2ce7d297d04869baf1c9e30d2c0
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
@@ -871,6 +881,7 @@ CHECKSUMS
   packs-rails (0.1.0) sha256=46c8b0292ea7fb0582557e7c84cdc43c9f7aaa6eeb3bc547dea029ccbd1a058b
   packs-specification (0.0.11) sha256=2b6ba6e0dd79af599796d4c8203234ce9a626bca42cb36fcceeac3d95731c86d
   packwerk (3.3.0) sha256=5a23dfb161ce225dea02a7171dd038b21b77b7c685e37edd635cd75fb8b1a74f
+  paper_trail (17.0.0) sha256=1c2842061d3874ca7015908e821e2aa14f9b982af2acb2a7974713bf79021c85
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parse_packwerk (0.27.0) sha256=3d69a1b182aa3a3cc9bb179780346467e773deb40cf91380188ac6ca332622da
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
@@ -903,6 +914,7 @@ CHECKSUMS
   refract (1.1.0) sha256=ee3b9627e39f7692831101e2fedd73e0d09a592ff5d5c05f171d14211fc7a9c7
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  request_store (1.7.0) sha256=e1b75d5346a315f452242a68c937ef8e48b215b9453a77a6c0acdca2934c88cb
   reverse_markdown (3.0.2) sha256=818ebb92ce39dbb1a291690dd1ec9a6d62530d4725296b17e9c8f668f9a5b8af
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   roda (3.102.0) sha256=b2156fff6d2b1b52bfac39e4ccde0d820a26594f069c3d9e99cc0853f7ee7dcc

--- a/README.md
+++ b/README.md
@@ -347,4 +347,6 @@ config/
 docs/
   architecture.excalidraw       # App architecture diagram
   mcp-architecture.excalidraw   # MCP server diagram
+  notification-center.md        # Notifications feature guide
+  persistence-safety.md         # Soft delete + versioning + restore/revert (Phase 25)
 ```

--- a/app/actions/AGENTS.md
+++ b/app/actions/AGENTS.md
@@ -171,12 +171,15 @@ Events follow the pattern `entity.action`:
 | `trip.updated` | Trips::Update | `{ trip_id, changes }` |
 | `trip.state_changed` | Trips::TransitionState | `{ trip_id, from_state, to_state }` |
 | `trip.deleted` | Trips::Delete | `{ trip_id, trip_name }` |
+| `trip.restored` | Trips::Restore | `{ trip_id, trip_name }` |
 | `journal_entry.created` | JournalEntries::Create | `{ journal_entry_id, trip_id, actor_id }` |
 | `journal_entry.updated` | JournalEntries::Update | `{ journal_entry_id, trip_id, changes }` |
 | `journal_entry.deleted` | JournalEntries::Delete | `{ journal_entry_id, trip_id }` |
+| `journal_entry.restored` | JournalEntries::Restore | `{ journal_entry_id, trip_id }` |
 | `comment.created` | Comments::Create | `{ comment_id, journal_entry_id, actor_id }` |
 | `comment.updated` | Comments::Update | `{ comment_id, journal_entry_id, changes }` |
 | `comment.deleted` | Comments::Delete | `{ comment_id, journal_entry_id }` |
+| `comment.restored` | Comments::Restore | `{ comment_id, journal_entry_id }` |
 | `reaction.created` | Reactions::Toggle | `{ reaction_id, reactable_type, reactable_id }` |
 | `reaction.removed` | Reactions::Toggle | `{ reaction_id, reactable_type, reactable_id }` |
 | `export.requested` | Exports::RequestExport | `{ export_id, trip_id, user_id, format }` |

--- a/app/actions/comments/delete.rb
+++ b/app/actions/comments/delete.rb
@@ -13,7 +13,7 @@ module Comments
     private
 
     def destroy(comment)
-      comment.destroy!
+      comment.discard!
       Success()
     end
 

--- a/app/actions/comments/restore.rb
+++ b/app/actions/comments/restore.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Comments
+  class Restore < BaseAction
+    def call(comment:)
+      yield restore(comment)
+      yield emit_event(comment)
+      Success(comment)
+    end
+
+    private
+
+    def restore(comment)
+      comment.undiscard!
+      Success()
+    rescue Discard::RecordNotUndiscarded => e
+      Failure(e.message)
+    end
+
+    def emit_event(comment)
+      Rails.event.notify(
+        "comment.restored",
+        comment_id: comment.id, journal_entry_id: comment.journal_entry_id
+      )
+      Success()
+    end
+  end
+end

--- a/app/actions/journal_entries/create.rb
+++ b/app/actions/journal_entries/create.rb
@@ -12,9 +12,9 @@ module JournalEntries
     private
 
     def persist(params, trip, user)
-      entry = trip.journal_entries.create!(
-        params.merge(author: user)
-      )
+      entry = PaperTrail.request(whodunnit: Current.actor&.id) do
+        trip.journal_entries.create!(params.merge(author: user))
+      end
       Success(entry)
     rescue ActiveRecord::RecordInvalid => e
       Failure(e.record.errors)

--- a/app/actions/journal_entries/delete.rb
+++ b/app/actions/journal_entries/delete.rb
@@ -13,7 +13,7 @@ module JournalEntries
     private
 
     def destroy(journal_entry)
-      journal_entry.destroy!
+      journal_entry.discard!
       Success()
     end
 

--- a/app/actions/journal_entries/restore.rb
+++ b/app/actions/journal_entries/restore.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module JournalEntries
+  class Restore < BaseAction
+    def call(journal_entry:)
+      yield restore(journal_entry)
+      yield emit_event(journal_entry)
+      Success(journal_entry)
+    end
+
+    private
+
+    def restore(journal_entry)
+      journal_entry.undiscard!
+      Success()
+    rescue Discard::RecordNotUndiscarded => e
+      Failure(e.message)
+    end
+
+    def emit_event(journal_entry)
+      Rails.event.notify(
+        "journal_entry.restored",
+        journal_entry_id: journal_entry.id, trip_id: journal_entry.trip_id
+      )
+      Success()
+    end
+  end
+end

--- a/app/actions/journal_entries/update.rb
+++ b/app/actions/journal_entries/update.rb
@@ -11,7 +11,9 @@ module JournalEntries
     private
 
     def persist(journal_entry, params)
-      journal_entry.update!(params)
+      PaperTrail.request(whodunnit: Current.actor&.id) do
+        journal_entry.update!(params)
+      end
       Success()
     rescue ActiveRecord::RecordInvalid => e
       Failure(e.record.errors)

--- a/app/actions/trips/delete.rb
+++ b/app/actions/trips/delete.rb
@@ -13,7 +13,7 @@ module Trips
     private
 
     def destroy(trip)
-      trip.destroy!
+      trip.discard!
       Success()
     end
 

--- a/app/actions/trips/restore.rb
+++ b/app/actions/trips/restore.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Trips
+  class Restore < BaseAction
+    def call(trip:)
+      yield restore(trip)
+      yield emit_event(trip)
+      Success(trip)
+    end
+
+    private
+
+    def restore(trip)
+      trip.undiscard!
+      Success()
+    rescue Discard::RecordNotUndiscarded => e
+      Failure(e.message)
+    end
+
+    def emit_event(trip)
+      Rails.event.notify(
+        "trip.restored", trip_id: trip.id, trip_name: trip.name
+      )
+      Success()
+    end
+  end
+end

--- a/app/components/audit_log_card.rb
+++ b/app/components/audit_log_card.rb
@@ -40,7 +40,12 @@ module Components
 
     private
 
+    # Only a deletion row offers restore. Without this gate every row sharing
+    # this auditable_id (created/updated/restored/…) would show the button,
+    # because @restorable is keyed by auditable_id, not by event.
     def restorable_record
+      return nil unless @log.action.to_s.end_with?(".deleted")
+
       @restorable[@log.auditable_id]
     end
 

--- a/app/components/audit_log_card.rb
+++ b/app/components/audit_log_card.rb
@@ -18,11 +18,14 @@ module Components
     }.freeze
 
     # restorable maps auditable_id => the currently-discarded record the viewer
-    # may restore (computed + authorised in the controller). Defaults to {} so
-    # the live-stream render path (RecordAuditLogJob) is unaffected.
-    def initialize(audit_log:, restorable: {})
+    # may restore; revertable maps audit_log_id => the kept record whose update
+    # this row may revert (both computed + authorised in the controller).
+    # Default to {} so the live-stream render path (RecordAuditLogJob) is
+    # unaffected.
+    def initialize(audit_log:, restorable: {}, revertable: {})
       @log = audit_log
       @restorable = restorable
+      @revertable = revertable
     end
 
     def view_template
@@ -34,11 +37,30 @@ module Components
           render_state_change if state_change?
           render_meta
           render_restore if restorable_record
+          render_revert if revertable_record
         end
       end
     end
 
     private
+
+    # Keyed by log id (not auditable_id): each update row reverts its own diff.
+    def revertable_record
+      @revertable[@log.id]
+    end
+
+    def render_revert
+      button_to(
+        "Revert",
+        view_context.revert_trip_audit_log_path(@log.trip_id, @log.id),
+        method: :patch,
+        class: "mt-3 ha-button ha-button-secondary text-xs",
+        form: {
+          class: "inline-flex",
+          data: { turbo_confirm: "Revert this change?" }
+        }
+      )
+    end
 
     # Only a deletion row offers restore. Without this gate every row sharing
     # this auditable_id (created/updated/restored/…) would show the button,

--- a/app/components/audit_log_card.rb
+++ b/app/components/audit_log_card.rb
@@ -11,13 +11,18 @@ module Components
   class AuditLogCard < Components::Base
     include Phlex::Rails::Helpers::DOMID
     include Phlex::Rails::Helpers::TimeAgoInWords
+    include Phlex::Rails::Helpers::ButtonTo
 
     SOURCE_BADGES = {
       "mcp" => "Agent", "telegram" => "Telegram", "system" => "System"
     }.freeze
 
-    def initialize(audit_log:)
+    # restorable maps auditable_id => the currently-discarded record the viewer
+    # may restore (computed + authorised in the controller). Defaults to {} so
+    # the live-stream render path (RecordAuditLogJob) is unaffected.
+    def initialize(audit_log:, restorable: {})
       @log = audit_log
+      @restorable = restorable
     end
 
     def view_template
@@ -28,11 +33,39 @@ module Components
           render_changes if changes.present?
           render_state_change if state_change?
           render_meta
+          render_restore if restorable_record
         end
       end
     end
 
     private
+
+    def restorable_record
+      @restorable[@log.auditable_id]
+    end
+
+    def render_restore
+      button_to(
+        "Restore",
+        restore_path(restorable_record),
+        method: :patch,
+        class: "mt-3 ha-button ha-button-secondary text-xs",
+        form: { class: "inline-flex" }
+      )
+    end
+
+    def restore_path(record)
+      case record
+      when Trip
+        view_context.restore_trip_path(record)
+      when JournalEntry
+        view_context.restore_trip_journal_entry_path(record.trip_id, record)
+      when Comment
+        view_context.restore_trip_journal_entry_comment_path(
+          @log.trip_id, record.journal_entry_id, record
+        )
+      end
+    end
 
     def row_css
       base = "relative flex gap-4 group"

--- a/app/controllers/audit_logs_controller.rb
+++ b/app/controllers/audit_logs_controller.rb
@@ -4,8 +4,16 @@ class AuditLogsController < ApplicationController
   before_action :require_authenticated_user!
   before_action :set_trip
 
-  RESTORABLE_TYPES = {
+  AUDITABLE_MODELS = {
     "Trip" => Trip, "JournalEntry" => JournalEntry, "Comment" => Comment
+  }.freeze
+
+  UPDATE_ACTIONS = {
+    "Trip" => ->(rec, params) { Trips::Update.new.call(trip: rec, params:) },
+    "JournalEntry" => lambda { |rec, params|
+      JournalEntries::Update.new.call(journal_entry: rec, params:)
+    },
+    "Comment" => ->(rec, params) { Comments::Update.new.call(comment: rec, params:) }
   }.freeze
 
   # Q2 (flag #1): viewers/guests are "hidden entirely" — return 404 for
@@ -30,8 +38,22 @@ class AuditLogsController < ApplicationController
     render Views::AuditLogs::Index.new(
       trip: @trip, audit_logs: @audit_logs,
       show_low_signal: @show_low_signal,
-      restorable: build_restorable(@audit_logs)
+      restorable: build_restorable(@audit_logs),
+      revertable: build_revertable(@audit_logs)
     )
+  end
+
+  # Re-applies the old values recorded in an *.updated row's diff, through the
+  # record's normal Update action (so the revert is itself a forward audit +
+  # version event). Body rich text is not a column, so it never appears in the
+  # diff and is out of scope here.
+  def revert
+    log = AuditLog.for_trip(@trip).find(params.expect(:id))
+    record = revert_target(log)
+    return head :not_found unless record
+
+    authorize! record, to: :update?
+    apply_revert(log, record)
   end
 
   private
@@ -50,7 +72,7 @@ class AuditLogsController < ApplicationController
   # rows the user may restore. Batch-loaded per type (no N+1 across the feed).
   def build_restorable(logs)
     ids_by_type = deletion_ids_by_type(logs)
-    RESTORABLE_TYPES.each_with_object({}) do |(type, klass), acc|
+    AUDITABLE_MODELS.each_with_object({}) do |(type, klass), acc|
       discarded_records(klass, ids_by_type[type]).find_each do |record|
         acc[record.id] = record if restorable?(record)
       end
@@ -79,5 +101,54 @@ class AuditLogsController < ApplicationController
                   else true
                   end
     parent_kept && allowed_to?(:restore?, record)
+  end
+
+  # Maps audit_log_id => the kept record, for *.updated rows the user may
+  # revert. Keyed by log id (not auditable_id): each update row reverts its own
+  # diff, so the button is per-event.
+  def build_revertable(logs)
+    update_logs = logs.select { |l| revertable_action?(l) }
+    records = kept_records_by_id(update_logs)
+    update_logs.each_with_object({}) do |log, acc|
+      record = records[log.auditable_id]
+      acc[log.id] = record if record && allowed_to?(:update?, record)
+    end
+  end
+
+  def revertable_action?(log)
+    log.action.to_s.end_with?(".updated") &&
+      AUDITABLE_MODELS.key?(log.auditable_type) &&
+      diff_for(log).present?
+  end
+
+  def kept_records_by_id(logs)
+    logs.group_by(&:auditable_type).each_with_object({}) do |(type, ls), acc|
+      AUDITABLE_MODELS[type].where(id: ls.map(&:auditable_id))
+                            .find_each { |r| acc[r.id] = r }
+    end
+  end
+
+  # The audit row stores changes as { field => [old, new] }; reverting re-applies
+  # the old values.
+  def revert_target(log)
+    return nil unless revertable_action?(log)
+
+    AUDITABLE_MODELS[log.auditable_type].find_by(id: log.auditable_id)
+  end
+
+  def apply_revert(log, record)
+    old_values = diff_for(log).transform_values { |(old, _new)| old }
+    result = UPDATE_ACTIONS.fetch(log.auditable_type).call(record, old_values)
+    case result
+    in Dry::Monads::Success
+      redirect_to trip_audit_logs_path(@trip), notice: "Change reverted."
+    in Dry::Monads::Failure
+      redirect_to trip_audit_logs_path(@trip),
+                  alert: "Could not revert that change."
+    end
+  end
+
+  def diff_for(log)
+    log.metadata.is_a?(Hash) ? log.metadata["changes"] : nil
   end
 end

--- a/app/controllers/audit_logs_controller.rb
+++ b/app/controllers/audit_logs_controller.rb
@@ -4,6 +4,10 @@ class AuditLogsController < ApplicationController
   before_action :require_authenticated_user!
   before_action :set_trip
 
+  RESTORABLE_TYPES = {
+    "Trip" => Trip, "JournalEntry" => JournalEntry, "Comment" => Comment
+  }.freeze
+
   # Q2 (flag #1): viewers/guests are "hidden entirely" — return 404 for
   # this controller instead of the app-wide 403 so the feed's existence
   # is not disclosed.
@@ -25,7 +29,8 @@ class AuditLogsController < ApplicationController
 
     render Views::AuditLogs::Index.new(
       trip: @trip, audit_logs: @audit_logs,
-      show_low_signal: @show_low_signal
+      show_low_signal: @show_low_signal,
+      restorable: build_restorable(@audit_logs)
     )
   end
 
@@ -39,5 +44,40 @@ class AuditLogsController < ApplicationController
     return scope if params[:before].blank?
 
     scope.where(occurred_at: ...(params[:before]))
+  end
+
+  # Maps auditable_id => the currently-discarded record, for *.deleted feed
+  # rows the user may restore. Batch-loaded per type (no N+1 across the feed).
+  def build_restorable(logs)
+    ids_by_type = deletion_ids_by_type(logs)
+    RESTORABLE_TYPES.each_with_object({}) do |(type, klass), acc|
+      discarded_records(klass, ids_by_type[type]).find_each do |record|
+        acc[record.id] = record if restorable?(record)
+      end
+    end
+  end
+
+  def deletion_ids_by_type(logs)
+    logs.select { |l| l.action.to_s.end_with?(".deleted") }
+        .group_by(&:auditable_type)
+  end
+
+  def discarded_records(klass, logs)
+    ids = logs&.map(&:auditable_id)
+    return klass.none if ids.blank?
+
+    klass.with_discarded.where(id: ids).where.not(discarded_at: nil)
+  end
+
+  # Offer restore only when the parent chain is kept (so the path and policy
+  # resolve, and we don't surface a child buried under a discarded parent) and
+  # the user is authorised.
+  def restorable?(record)
+    parent_kept = case record
+                  when JournalEntry then record.trip.present?
+                  when Comment then record.journal_entry.present?
+                  else true
+                  end
+    parent_kept && allowed_to?(:restore?, record)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,6 +7,7 @@ class CommentsController < ApplicationController
   before_action :set_trip
   before_action :set_journal_entry
   before_action :set_comment, only: %i[update destroy]
+  before_action :set_discarded_comment, only: %i[restore]
   before_action :authorize_comment!
 
   def create
@@ -56,6 +57,12 @@ class CommentsController < ApplicationController
     end
   end
 
+  def restore
+    Comments::Restore.new.call(comment: @comment)
+    redirect_to trip_path(@trip, anchor: dom_id(@journal_entry)),
+                notice: "Comment restored."
+  end
+
   private
 
   def set_trip
@@ -70,6 +77,11 @@ class CommentsController < ApplicationController
 
   def set_comment
     @comment = @journal_entry.comments.find(params[:id])
+  end
+
+  # Restore targets a soft-deleted comment, hidden by the default kept scope.
+  def set_discarded_comment
+    @comment = @journal_entry.comments.with_discarded.find(params[:id])
   end
 
   def authorize_comment!

--- a/app/controllers/journal_entries_controller.rb
+++ b/app/controllers/journal_entries_controller.rb
@@ -6,6 +6,7 @@ class JournalEntriesController < ApplicationController
   before_action :require_authenticated_user!
   before_action :set_trip
   before_action :set_journal_entry, only: %i[edit update destroy]
+  before_action :set_discarded_journal_entry, only: %i[restore]
   before_action :authorize_journal_entry!
 
   def new
@@ -63,6 +64,12 @@ class JournalEntriesController < ApplicationController
     redirect_to @trip, notice: "Entry deleted.", status: :see_other
   end
 
+  def restore
+    JournalEntries::Restore.new.call(journal_entry: @journal_entry)
+    redirect_to trip_path(@trip, anchor: dom_id(@journal_entry)),
+                notice: "Entry restored."
+  end
+
   private
 
   def set_trip
@@ -71,6 +78,11 @@ class JournalEntriesController < ApplicationController
 
   def set_journal_entry
     @journal_entry = @trip.journal_entries.find(params[:id])
+  end
+
+  # Restore targets a soft-deleted entry, hidden by the default kept scope.
+  def set_discarded_journal_entry
+    @journal_entry = @trip.journal_entries.with_discarded.find(params[:id])
   end
 
   def authorize_journal_entry!

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -9,7 +9,10 @@ class TripsController < ApplicationController
 
   def index
     base = current_user.role?(:superadmin) ? Trip.all : current_user.trips
-    @discarded = params[:discarded].present?
+    # Enforce the trash view in the controller, not just by hiding the link:
+    # restore is superadmin-only, so a non-restorer requesting ?discarded=1
+    # falls back to the kept list (no deletion metadata disclosure).
+    @discarded = params[:discarded].present? && allowed_to?(:restore?, Trip)
     # .with_discarded.discarded — a bare .discarded would self-contradict the
     # default kept scope (discarded_at IS NULL AND IS NOT NULL).
     @trips = @discarded ? base.with_discarded.discarded : base

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -4,16 +4,17 @@ class TripsController < ApplicationController
   before_action :require_authenticated_user!
   before_action :set_trip,
                 only: %i[show edit update destroy transition gallery]
+  before_action :set_discarded_trip, only: %i[restore]
   before_action :authorize_trip!
 
   def index
-    @trips = if current_user.role?(:superadmin)
-               Trip.all
-             else
-               current_user.trips
-             end
+    base = current_user.role?(:superadmin) ? Trip.all : current_user.trips
+    @discarded = params[:discarded].present?
+    # .with_discarded.discarded — a bare .discarded would self-contradict the
+    # default kept scope (discarded_at IS NULL AND IS NOT NULL).
+    @trips = @discarded ? base.with_discarded.discarded : base
     render Views::Trips::Index.new(
-      trips: @trips.order(created_at: :desc)
+      trips: @trips.order(created_at: :desc), discarded: @discarded
     )
   end
 
@@ -92,6 +93,11 @@ class TripsController < ApplicationController
                             status: :see_other
   end
 
+  def restore
+    Trips::Restore.new.call(trip: @trip)
+    redirect_to trip_path(@trip), notice: "Trip restored."
+  end
+
   def transition
     result = Trips::TransitionState.new.call(
       trip: @trip, new_state: params[:state]
@@ -111,6 +117,11 @@ class TripsController < ApplicationController
 
   def set_trip
     @trip = Trip.find(params[:id])
+  end
+
+  # Restore targets a soft-deleted trip, hidden by the default kept scope.
+  def set_discarded_trip
+    @trip = Trip.with_discarded.find(params[:id])
   end
 
   def authorize_trip!

--- a/app/models/audit_log/builder.rb
+++ b/app/models/audit_log/builder.rb
@@ -13,7 +13,7 @@ class AuditLog
       "videos_added" => "added videos to",
       "toggled" => "toggled an item in", "submitted" => "submitted",
       "approved" => "approved", "rejected" => "rejected",
-      "sent" => "sent", "accepted" => "accepted"
+      "sent" => "sent", "accepted" => "accepted", "restored" => "restored"
     }.freeze
 
     # Namespaced models (extracted into packs) need an explicit mapping so the
@@ -58,7 +58,9 @@ class AuditLog
     # --- per-entity subjects -------------------------------------------
 
     def trip_subject
-      trip = Trip.find_by(id: @payload[:trip_id])
+      # with_discarded: delete events fire after the record is soft-deleted, so
+      # the default `kept` scope would hide it and lose the summary.
+      trip = Trip.with_discarded.find_by(id: @payload[:trip_id])
       name = trip&.name || @payload[:trip_name]
       base(@payload[:trip_id], trip_id: @payload[:trip_id],
                                record: trip, owner: trip&.created_by,
@@ -66,19 +68,19 @@ class AuditLog
     end
 
     def journal_entry_subject
-      entry = JournalEntry.find_by(id: @payload[:journal_entry_id])
+      entry = JournalEntry.with_discarded.find_by(id: @payload[:journal_entry_id])
       base(@payload[:journal_entry_id],
            trip_id: @payload[:trip_id], record: entry,
            owner: entry&.author,
            target: entry ? %(journal entry "#{entry.name}") : "a journal entry")
     end
 
-    # Resolve trip via the (surviving) journal entry, not the comment:
-    # comment.deleted is emitted after destroy!, so the comment row is
-    # gone and only journal_entry_id is in the payload.
+    # Resolve trip via the journal entry (its id is always in the payload).
+    # with_discarded: a comment/entry may be soft-deleted by the time the event
+    # is built, and the default `kept` scope would hide it.
     def comment_subject
-      comment = Comment.find_by(id: @payload[:comment_id])
-      entry = JournalEntry.find_by(id: @payload[:journal_entry_id])
+      comment = Comment.with_discarded.find_by(id: @payload[:comment_id])
+      entry = JournalEntry.with_discarded.find_by(id: @payload[:journal_entry_id])
       base(@payload[:comment_id], trip_id: entry&.trip_id, record: comment,
                                   owner: comment&.user, target: "a comment")
     end
@@ -98,9 +100,9 @@ class AuditLog
       when "Trip"
         @payload[:reactable_id]
       when "JournalEntry"
-        JournalEntry.find_by(id: @payload[:reactable_id])&.trip_id
+        JournalEntry.with_discarded.find_by(id: @payload[:reactable_id])&.trip_id
       when "Comment"
-        Comment.find_by(id: @payload[:reactable_id])
+        Comment.with_discarded.find_by(id: @payload[:reactable_id])
                &.journal_entry&.trip_id
       end
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 class Comment < ApplicationRecord
+  include Discard::Model
+
   belongs_to :journal_entry
   belongs_to :user
 
   has_many :reactions, as: :reactable, dependent: :destroy
 
   validates :body, presence: true
+
+  default_scope -> { kept }
 
   scope :chronological, -> { order(created_at: :asc, id: :asc) }
 end

--- a/app/models/journal_entry.rb
+++ b/app/models/journal_entry.rb
@@ -17,6 +17,12 @@ class JournalEntry < ApplicationRecord
   has_many :subscribers, through: :journal_entry_subscriptions,
                          source: :user
 
+  # Version the title. `only: [:name]` already excludes discarded_at, so a
+  # discard never creates a title version. The rich-text *content* (body) is a
+  # separate ActionText::RichText record, versioned via the paper_trail
+  # initializer (config/initializers/paper_trail_action_text.rb).
+  has_paper_trail only: %i[name], on: %i[create update]
+
   validates :name, presence: true
   validates :entry_date, presence: true
 

--- a/app/models/journal_entry.rb
+++ b/app/models/journal_entry.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class JournalEntry < ApplicationRecord
+  include Discard::Model
+
   belongs_to :trip
   belongs_to :author, class_name: "User"
 
@@ -17,6 +19,11 @@ class JournalEntry < ApplicationRecord
 
   validates :name, presence: true
   validates :entry_date, presence: true
+
+  default_scope -> { kept }
+
+  # Cascade discard down to comments. Restore is parent-only by design.
+  after_discard { comments.kept.find_each(&:discard) }
 
   scope :chronological, lambda {
     order(entry_date: :asc, created_at: :asc, id: :asc)

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -11,6 +11,8 @@ class Trip < ApplicationRecord
 
   class InvalidTransitionError < StandardError; end
 
+  include Discard::Model
+
   enum :state, {
     planning: 0, started: 1, cancelled: 2, finished: 3, archived: 4
   }
@@ -25,6 +27,12 @@ class Trip < ApplicationRecord
   has_many :reactions, as: :reactable, dependent: :destroy
 
   validates :name, presence: true
+
+  default_scope -> { kept }
+
+  # Cascade discard down to entries (which cascade to their comments). Restore
+  # is parent-only by design, so there is no after_undiscard counterpart.
+  after_discard { journal_entries.kept.find_each(&:discard) }
 
   def transition_to!(new_state)
     new_state = new_state.to_sym

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -17,6 +17,11 @@ class CommentPolicy < ApplicationPolicy
     (superadmin? || own_comment?) && trip.commentable?
   end
 
+  # Mirrors destroy? — whoever may soft-delete may restore.
+  def restore?
+    (superadmin? || own_comment?) && trip.commentable?
+  end
+
   private
 
   def trip

--- a/app/policies/journal_entry_policy.rb
+++ b/app/policies/journal_entry_policy.rb
@@ -25,6 +25,11 @@ class JournalEntryPolicy < ApplicationPolicy
     (superadmin? || (contributor? && own_entry?)) && record.trip.writable?
   end
 
+  # Mirrors destroy? — whoever may soft-delete may restore.
+  def restore?
+    (superadmin? || (contributor? && own_entry?)) && record.trip.writable?
+  end
+
   private
 
   def trip_membership

--- a/app/policies/trip_policy.rb
+++ b/app/policies/trip_policy.rb
@@ -34,6 +34,11 @@ class TripPolicy < ApplicationPolicy
     superadmin?
   end
 
+  # Mirrors destroy? — whoever may soft-delete may restore.
+  def restore?
+    superadmin?
+  end
+
   def transition?
     superadmin?
   end

--- a/app/views/audit_logs/index.rb
+++ b/app/views/audit_logs/index.rb
@@ -6,11 +6,12 @@ module Views
       include Phlex::Rails::Helpers::LinkTo
 
       def initialize(trip:, audit_logs:, show_low_signal: false,
-                     restorable: {})
+                     restorable: {}, revertable: {})
         @trip = trip
         @audit_logs = audit_logs
         @show_low_signal = show_low_signal
         @restorable = restorable
+        @revertable = revertable
       end
 
       def view_template
@@ -77,7 +78,8 @@ module Views
             div(class: "space-y-6") do
               logs.each do |log|
                 render Components::AuditLogCard.new(
-                  audit_log: log, restorable: @restorable
+                  audit_log: log, restorable: @restorable,
+                  revertable: @revertable
                 )
               end
             end

--- a/app/views/audit_logs/index.rb
+++ b/app/views/audit_logs/index.rb
@@ -5,10 +5,12 @@ module Views
     class Index < Views::Base
       include Phlex::Rails::Helpers::LinkTo
 
-      def initialize(trip:, audit_logs:, show_low_signal: false)
+      def initialize(trip:, audit_logs:, show_low_signal: false,
+                     restorable: {})
         @trip = trip
         @audit_logs = audit_logs
         @show_low_signal = show_low_signal
+        @restorable = restorable
       end
 
       def view_template
@@ -74,7 +76,9 @@ module Views
             p(class: "ha-overline mb-4 px-2") { plain date_label(date) }
             div(class: "space-y-6") do
               logs.each do |log|
-                render Components::AuditLogCard.new(audit_log: log)
+                render Components::AuditLogCard.new(
+                  audit_log: log, restorable: @restorable
+                )
               end
             end
           end

--- a/app/views/trips/index.rb
+++ b/app/views/trips/index.rb
@@ -4,27 +4,21 @@ module Views
   module Trips
     class Index < Views::Base
       include Phlex::Rails::Helpers::LinkTo
+      include Phlex::Rails::Helpers::ButtonTo
 
-      def initialize(trips:)
+      def initialize(trips:, discarded: false)
         @trips = trips
+        @discarded = discarded
       end
 
       def view_template
         div(class: "space-y-10") do
           render Components::PageHeader.new(
             section: "Trips",
-            title: "My Trips",
-            subtitle: "Your travel journal collection."
+            title: @discarded ? "Recently Deleted" : "My Trips",
+            subtitle: @discarded ? "Soft-deleted trips you can restore." : "Your travel journal collection."
           ) do
-            if view_context.allowed_to?(:create?, Trip)
-              link_to(
-                view_context.new_trip_path,
-                class: "ha-button ha-button-primary"
-              ) do
-                render Components::Icons::Plus.new(css: "h-5 w-5")
-                plain "New Trip"
-              end
-            end
+            header_actions
           end
 
           if view_context.notice.present?
@@ -34,11 +28,7 @@ module Views
           end
 
           if @trips.any?
-            div(id: "trips", class: "grid gap-8 md:grid-cols-2") do
-              @trips.each do |trip|
-                render Components::TripCard.new(trip: trip)
-              end
-            end
+            render_trip_grid
           else
             render_empty_state
           end
@@ -47,15 +37,79 @@ module Views
 
       private
 
+      def header_actions
+        if @discarded
+          link_to(view_context.trips_path, class: "ha-button ha-button-secondary") do
+            plain "Back to trips"
+          end
+        else
+          trash_link
+          new_trip_button
+        end
+      end
+
+      def trash_link
+        return unless view_context.allowed_to?(:restore?, Trip)
+
+        link_to(
+          view_context.trips_path(discarded: 1),
+          class: "ha-button ha-button-secondary"
+        ) do
+          plain "Recently deleted"
+        end
+      end
+
+      def new_trip_button
+        return unless view_context.allowed_to?(:create?, Trip)
+
+        link_to(
+          view_context.new_trip_path,
+          class: "ha-button ha-button-primary"
+        ) do
+          render Components::Icons::Plus.new(css: "h-5 w-5")
+          plain "New Trip"
+        end
+      end
+
+      def render_trip_grid
+        div(id: "trips", class: "grid gap-8 md:grid-cols-2") do
+          @trips.each do |trip|
+            if @discarded
+              render_discarded_card(trip)
+            else
+              render Components::TripCard.new(trip: trip)
+            end
+          end
+        end
+      end
+
+      def render_discarded_card(trip)
+        div(class: "ha-card flex items-center justify-between gap-4 p-6") do
+          div do
+            h3(class: "font-headline text-lg font-bold") { plain trip.name }
+            p(class: "mt-1 text-sm text-[var(--ha-on-surface-variant)]") do
+              plain "Deleted #{trip.discarded_at.to_date.to_fs(:long)}"
+            end
+          end
+          if view_context.allowed_to?(:restore?, trip)
+            button_to(
+              view_context.restore_trip_path(trip),
+              method: :patch,
+              class: "ha-button ha-button-primary"
+            ) { plain "Restore" }
+          end
+        end
+      end
+
       def render_empty_state
         div(class: "ha-card p-12 text-center") do
           h3(class: "font-headline text-xl font-bold") do
-            plain "No trips yet"
+            plain @discarded ? "No deleted trips" : "No trips yet"
           end
           p(class: "mt-2 text-sm text-[var(--ha-on-surface-variant)]") do
-            plain "Trips will appear here once created."
+            plain(@discarded ? "Deleted trips will appear here." : "Trips will appear here once created.")
           end
-          if view_context.allowed_to?(:create?, Trip)
+          if !@discarded && view_context.allowed_to?(:create?, Trip)
             div(class: "mt-6") do
               link_to(
                 view_context.new_trip_path,

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Serialize version snapshots as JSON rather than the default YAML.
+#
+# Psych 4's safe_load rejects ActiveSupport::TimeWithZone (and other rich
+# types) on reify, raising Psych::DisallowedClass. The JSON serializer sidesteps
+# this entirely: object / object_changes are stored as JSON in the text columns
+# and reify reassigns plain values that Active Record type-casts back. This is
+# the reliable path for restoring a prior title/content revision.
+PaperTrail.serializer = PaperTrail::Serializers::JSON

--- a/config/initializers/paper_trail_action_text.rb
+++ b/config/initializers/paper_trail_action_text.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Version the rich-text *content* of journal entries.
+#
+# JournalEntry#body is `has_rich_text :body` — a separate ActionText::RichText
+# row, not a column on journal_entries. paper_trail on JournalEntry alone would
+# version the title (`name`) but never the body. Enabling paper_trail on
+# ActionText::RichText captures every body edit as a revertible version.
+#
+# Only the journal entry body uses rich text in this app (trip/comment bodies
+# are plain text), so this is narrowly scoped in practice. The version inherits
+# the same PaperTrail.request.whodunnit as the parent write, because Action Text
+# saves the rich text inside the parent's save (same request block).
+ActiveSupport.on_load(:action_text_rich_text) do
+  include PaperTrail::Model
+
+  has_paper_trail on: %i[create update]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,10 +27,17 @@ Rails.application.routes.draw do
   # Core domain
   resources :trips do
     resources :journal_entries, except: %i[index show] do
+      member do
+        patch :restore
+      end
       resource :subscription,
                only: %i[create destroy],
                controller: "journal_entry_subscriptions"
-      resources :comments, only: %i[create update destroy]
+      resources :comments, only: %i[create update destroy] do
+        member do
+          patch :restore
+        end
+      end
       resources :reactions, only: %i[create destroy]
     end
     # Checklist controllers live in the Checklists pack (Checklists:: module).
@@ -55,6 +62,7 @@ Rails.application.routes.draw do
     resources :audit_logs, only: [:index], path: "activity"
     member do
       patch :transition
+      patch :restore
       get :gallery
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,11 @@ Rails.application.routes.draw do
         get :download
       end
     end
-    resources :audit_logs, only: [:index], path: "activity"
+    resources :audit_logs, only: [:index], path: "activity" do
+      member do
+        patch :revert
+      end
+    end
     member do
       patch :transition
       patch :restore

--- a/db/migrate/20260530100000_add_discarded_at_to_critical_models.rb
+++ b/db/migrate/20260530100000_add_discarded_at_to_critical_models.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddDiscardedAtToCriticalModels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :trips, :discarded_at, :datetime
+    add_column :journal_entries, :discarded_at, :datetime
+    add_column :comments, :discarded_at, :datetime
+
+    add_index :trips, :discarded_at
+    add_index :journal_entries, :discarded_at
+    add_index :comments, :discarded_at
+  end
+end

--- a/db/migrate/20260530153128_create_versions.rb
+++ b/db/migrate/20260530153128_create_versions.rb
@@ -3,8 +3,9 @@
 # Creates the paper_trail `versions` table. UUID-corrected for this app:
 # the table itself uses a UUID PK and `item_id` is a UUID (all app PKs are
 # UUID, stored via the sqlite_crypto fork — mirrors db/audit_logs).
-# `object` / `object_changes` keep paper_trail's default text + YAML serializer
-# (most battle-tested for `reify`); SQLite ignores the byte limit.
+# `object` / `object_changes` are text columns holding JSON (the JSON serializer
+# is configured in config/initializers/paper_trail.rb so reify avoids Psych 4's
+# safe_load class restrictions); SQLite ignores the byte limit.
 class CreateVersions < ActiveRecord::Migration[8.1]
   TEXT_BYTES = 1_073_741_823
 

--- a/db/migrate/20260530153128_create_versions.rb
+++ b/db/migrate/20260530153128_create_versions.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Creates the paper_trail `versions` table. UUID-corrected for this app:
+# the table itself uses a UUID PK and `item_id` is a UUID (all app PKs are
+# UUID, stored via the sqlite_crypto fork — mirrors db/audit_logs).
+# `object` / `object_changes` keep paper_trail's default text + YAML serializer
+# (most battle-tested for `reify`); SQLite ignores the byte limit.
+class CreateVersions < ActiveRecord::Migration[8.1]
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions, id: :uuid do |t|
+      t.string   :whodunnit
+      t.datetime :created_at
+      t.uuid     :item_id,   null: false
+      t.string   :item_type, null: false
+      t.string   :event,     null: false
+      t.text     :object, limit: TEXT_BYTES
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20260530153129_add_object_changes_to_versions.rb
+++ b/db/migrate/20260530153129_add_object_changes_to_versions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Adds the optional `object_changes` column where paper_trail stores the
+# per-update diff (`--with-changes`). Text + YAML, matching `object`.
+class AddObjectChangesToVersions < ActiveRecord::Migration[8.1]
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+  end
+end

--- a/db/migrate/20260530153129_add_object_changes_to_versions.rb
+++ b/db/migrate/20260530153129_add_object_changes_to_versions.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # Adds the optional `object_changes` column where paper_trail stores the
-# per-update diff (`--with-changes`). Text + YAML, matching `object`.
+# per-update diff (`--with-changes`). Text column holding JSON, matching
+# `object` (the JSON serializer is set in config/initializers/paper_trail.rb).
 class AddObjectChangesToVersions < ActiveRecord::Migration[8.1]
   TEXT_BYTES = 1_073_741_823
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_30_100000) do
   create_table "access_requests", id: uuid, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
@@ -127,10 +127,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
   create_table "comments", id: uuid, force: :cascade do |t|
     t.text "body", null: false
     t.datetime "created_at", null: false
+    t.datetime "discarded_at"
     t.string "journal_entry_id", limit: 36, null: false
     t.string "telegram_message_id"
     t.datetime "updated_at", null: false
     t.string "user_id", limit: 36, null: false
+    t.index ["discarded_at"], name: "index_comments_on_discarded_at"
     t.index ["journal_entry_id", "created_at"], name: "index_comments_on_journal_entry_id_and_created_at"
     t.index ["journal_entry_id", "telegram_message_id"], name: "idx_comments_telegram_idempotency", unique: true, where: "telegram_message_id IS NOT NULL"
     t.index ["journal_entry_id"], name: "index_comments_on_journal_entry_id"
@@ -170,6 +172,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
     t.string "author_id", limit: 36, null: false
     t.datetime "created_at", null: false
     t.text "description"
+    t.datetime "discarded_at"
     t.date "entry_date", null: false
     t.decimal "latitude", precision: 10, scale: 7
     t.string "location_name"
@@ -180,6 +183,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
     t.string "trip_id", limit: 36, null: false
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_journal_entries_on_author_id"
+    t.index ["discarded_at"], name: "index_journal_entries_on_discarded_at"
     t.index ["telegram_message_id"], name: "index_journal_entries_on_telegram_message_id"
     t.index ["trip_id", "entry_date", "created_at", "id"], name: "idx_journal_entries_chronological"
     t.index ["trip_id", "telegram_message_id"], name: "idx_journal_entries_telegram_idempotency", unique: true, where: "telegram_message_id IS NOT NULL"
@@ -252,6 +256,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
     t.datetime "created_at", null: false
     t.string "created_by_id", limit: 36, null: false
     t.text "description"
+    t.datetime "discarded_at"
     t.date "end_date"
     t.json "metadata", default: {}, null: false
     t.string "name", null: false
@@ -259,6 +264,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_200000) do
     t.integer "state", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["created_by_id"], name: "index_trips_on_created_by_id"
+    t.index ["discarded_at"], name: "index_trips_on_discarded_at"
   end
 
   create_table "user_email_auth_keys", id: uuid, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_30_100000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_30_153129) do
   create_table "access_requests", id: uuid, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
@@ -314,6 +314,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_100000) do
     t.integer "status", default: 1, null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  create_table "versions", id: uuid, force: :cascade do |t|
+    t.datetime "created_at"
+    t.string "event", null: false
+    t.string "item_id", limit: 36, null: false
+    t.string "item_type", null: false
+    t.text "object", limit: 1073741823
+    t.text "object_changes", limit: 1073741823
+    t.string "whodunnit"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "access_requests", "users", column: "reviewed_by_id"

--- a/docs/persistence-safety.md
+++ b/docs/persistence-safety.md
@@ -1,0 +1,197 @@
+# Persistence safety (Phase 25)
+
+Three complementary systems protect the critical, user-authored models —
+`Trip`, `JournalEntry`, `Comment` — from accidental or malicious data loss.
+Each answers a different question:
+
+| System | Gem | The question it answers |
+|--------|-----|-------------------------|
+| **Soft delete** | `discard` | "It's gone — get it back." A deleted record is hidden, not destroyed, and can be restored with its whole child graph. |
+| **Versioning** | `paper_trail` | "What did this say before — undo the edit." Every title/body edit is a revertible snapshot. |
+| **AuditLog feed** | (Phase 21) | "Who did what — and the feed that surfaces Restore/Revert." The trip Activity feed renders the actions and the buttons to reverse them. |
+
+> All diagrams below are [Mermaid](https://mermaid.js.org/) — they render inline
+> on GitHub and can be pasted into <https://excalidraw.com> via
+> **Insert → Mermaid to Excalidraw** for free-form editing.
+
+---
+
+## 1. Record lifecycle
+
+A record is **Active** (kept) by default. `discard!` moves it to **Discarded**
+(sets `discarded_at`, hidden by `default_scope { kept }`); `undiscard!` brings it
+back. Editing a journal entry's title or body adds a `paper_trail` version
+without changing the lifecycle state.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active : create!
+    Active --> Discarded : discard!  (sets discarded_at)
+    Discarded --> Active : undiscard!  (parent-only)
+    Active --> Active : update! (name/body) adds a paper_trail version
+
+    note right of Active
+        default_scope { kept }
+        → discarded_at IS NULL
+        Visible everywhere: views,
+        MCP list_*, exports, counts,
+        left_joins ON-clauses.
+    end note
+
+    note right of Discarded
+        Hidden by the default scope.
+        Only with_discarded sees it.
+        Children cascade-discarded too:
+          Trip → journal_entries → comments
+        dependent: :destroy does NOT run,
+        so the whole graph survives intact.
+    end note
+```
+
+**Why the graph survives.** `discard` does not run validations and does not
+trigger `dependent: :destroy`. A discarded trip keeps its memberships,
+reactions, and attachments — that is precisely what lets a parent-only restore
+recover everything beneath it.
+
+**Cascade is down-only.** `Trip` has
+`after_discard { journal_entries.kept.find_each(&:discard) }` and `JournalEntry`
+has `after_discard { comments.kept.find_each(&:discard) }`. There is **no**
+`after_undiscard` counterpart — restore is parent-only by design, so restoring a
+trip does not auto-resurrect entries that were independently deleted first.
+
+---
+
+## 2. Delete → feed → restore
+
+Deleting routes through the `*::Delete` action, which discards (cascading down)
+and emits a `*.deleted` event. `AuditLogSubscriber` records it; the Activity feed
+then offers a **Restore** button on that row, which calls the `*::Restore` action.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant C as Controller
+    participant D as *::Delete action
+    participant M as Model (Trip/Entry/Comment)
+    participant E as Rails.event
+    participant AL as AuditLogSubscriber → AuditLog
+    participant F as Activity feed (/trips/:id/activity)
+    participant R as *::Restore action
+
+    U->>C: DELETE the record
+    C->>D: call(record:)
+    D->>M: record.discard!  (sets discarded_at)
+    M-->>M: after_discard → cascade children.kept.discard
+    D->>E: notify("trip.deleted" / "journal_entry.deleted" / "comment.deleted")
+    E-->>AL: emit(event) → Builder (with_discarded) → row
+    Note over F: build_restorable maps auditable_id → discarded record<br/>only if parent chain kept AND restore? allows
+    U->>F: open feed → sees "Restore" on the .deleted row
+    F->>R: PATCH restore → call(record:)
+    R->>M: record.undiscard!  (parent-only)
+    R->>E: notify("*.restored") → forward audit event
+```
+
+### Revert (an edit, not a delete)
+
+Each `*.updated` audit row carries its diff `{ field => [old, new] }` in
+`metadata["changes"]`. The feed's **Revert** button re-applies the *old* values
+through the record's normal Update action — so the revert is itself a forward
+audit + version event, never a history edit.
+
+```mermaid
+flowchart LR
+    A["*.updated audit row<br/>metadata['changes'] = { field => [old, new] }"]
+    A --> B["Feed Revert button<br/>(build_revertable, keyed by audit_log id)"]
+    B --> C["PATCH /trips/:id/activity/:id/revert"]
+    C --> D["old_values = take the old of each [old, new] pair"]
+    D --> E["record's Update action<br/>(Trips/JournalEntries/Comments::Update)"]
+    E --> F["forward audit event + paper_trail version"]
+
+    classDef step fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
+    class A,B,C,D,E,F step
+```
+
+**Coverage.** Revert handles column fields — trip title/description/location/
+dates and comment body. The journal-entry **rich-text body is not a column**, so
+it never appears in the feed diff and is intentionally out of scope for Revert
+(its history lives in `paper_trail` on `ActionText::RichText` instead).
+
+---
+
+## 3. Gotchas / rules
+
+- **Delete now means discard.** No real `destroy` fires for `Trip`,
+  `JournalEntry`, or `Comment`. `dependent: :destroy` only runs on an actual hard
+  destroy, which the app no longer triggers for these models.
+- **Use `with_discarded` everywhere you must see deleted rows** — restore paths,
+  admin/trash views, and `AuditLog::Builder` subject finders. The default `kept`
+  scope hides discarded rows from every other read path (this is the safety
+  guarantee, not a bug).
+- **`with_discarded.discarded`, never bare `.discarded`.** A bare `.discarded`
+  self-contradicts `default_scope { kept }` (`discarded_at IS NULL AND IS NOT
+  NULL` → always empty).
+- **`paper_trail` requires the JSON serializer for `reify`.** Psych 4
+  `safe_load` rejects `ActiveSupport::TimeWithZone`
+  (`Psych::DisallowedClass`); JSON snapshots type-cast back cleanly.
+- **The journal-entry body is versioned on `ActionText::RichText`, not on
+  `journal_entries` columns.** Body edits therefore do not appear as
+  Activity-feed column diffs.
+- **`discard` skips validations and `dependent: :destroy`.** A discarded trip
+  keeps its memberships, reactions, and attachments intact — that is what makes
+  restore recover the whole graph.
+- **Cascade is down-only.** Discarding a parent discards its kept children;
+  restoring a parent does **not** re-discard or re-restore children. Restore is
+  parent-only by design.
+
+---
+
+## 4. Where it lives
+
+```
+Models (include Discard::Model, default_scope { kept }, cascade after_discard)
+  app/models/trip.rb                # + after_discard → journal_entries
+  app/models/journal_entry.rb       # + after_discard → comments; has_paper_trail only: [:name]
+  app/models/comment.rb
+
+Actions
+  app/actions/trips/delete.rb              # discard!
+  app/actions/trips/restore.rb             # undiscard! + trip.restored
+  app/actions/journal_entries/delete.rb    # discard!
+  app/actions/journal_entries/restore.rb   # undiscard! + journal_entry.restored
+  app/actions/comments/delete.rb           # discard!
+  app/actions/comments/restore.rb          # undiscard! + comment.restored
+  app/actions/journal_entries/create.rb    # PaperTrail.request(whodunnit:)
+  app/actions/journal_entries/update.rb    # PaperTrail.request(whodunnit:)
+
+Initializers
+  config/initializers/paper_trail.rb              # JSON serializer (Psych 4 reify)
+  config/initializers/paper_trail_action_text.rb  # versions the rich-text body
+
+Migrations
+  db/migrate/20260530100000_add_discarded_at_to_critical_models.rb  # discarded_at + index
+  db/migrate/20260530153128_create_versions.rb                      # UUID-corrected versions table
+  db/migrate/20260530153129_add_object_changes_to_versions.rb       # object_changes diff column
+
+Feed integration (Phase 21 AuditLog)
+  app/models/audit_log/builder.rb           # subject finders use with_discarded
+  app/controllers/audit_logs_controller.rb  # build_restorable / build_revertable / #revert
+  app/controllers/trips_controller.rb       # ?discarded=1 trash view + #restore
+  app/components/audit_log_card.rb          # Restore + Revert buttons
+
+Policies (restore? mirrors destroy?)
+  app/policies/trip_policy.rb
+  app/policies/journal_entry_policy.rb
+  app/policies/comment_policy.rb
+
+Routes (config/routes.rb)
+  PATCH /trips/:id/restore
+  PATCH /trips/:trip_id/journal_entries/:id/restore
+  PATCH /trips/:trip_id/journal_entries/:journal_entry_id/comments/:id/restore
+  PATCH /trips/:trip_id/activity/:id/revert
+```
+
+---
+
+See the [Audit Journal (Phase 21)](../AGENTS.md) section in the root `AGENTS.md`
+for the underlying event-capture pipeline this feature builds on.

--- a/prompts/Phase 25 - Steps.md
+++ b/prompts/Phase 25 - Steps.md
@@ -90,3 +90,19 @@ Append-only audit trail. Plan: `prompts/Phase 25 Improve Persistance.md`.
   Request specs added (shows for restorable own; hidden once restored; hidden to
   a contributor on another's entry). Verified live: feed Restore button →
   "Entry restored." → entry back in the kept scope.
+- `e8ddc58` — fix: gate the feed Restore button on the row's own `.deleted`
+  action (it keyed on auditable_id, so every event for a discarded entry showed
+  Restore). Regression spec asserts exactly one button across deleted+updated+
+  restored.
+
+## Step 9b — Review feedback (revert edits from the feed)
+- User expected to restore content edits too. Chose "revert from feed rows".
+- `991eed7` — each `*.updated` row carries its diff `{ field => [old, new] }`;
+  a Revert button re-applies the old values via the record's Update action (a
+  forward audit + version event). Controller batch-loads kept auditables for
+  update rows, authorises with `update?`, keys the revert map by audit_log id
+  (per-row). PATCH `:revert` route + turbo-confirm button. Covers column fields
+  (title/description/location/dates) and comment body; journal-entry rich-text
+  body is not a column so it never appears in the feed diff (agreed out of
+  scope). Request specs (shows/reverts/no-button/404). Verified live: feed
+  Revert on a "Name: Foo → Bar" row restored the name to "Foo".

--- a/prompts/Phase 25 - Steps.md
+++ b/prompts/Phase 25 - Steps.md
@@ -77,4 +77,16 @@ Append-only audit trail. Plan: `prompts/Phase 25 Improve Persistance.md`.
   - Dark-mode toggle works.
 
 ## Step 9 — PR
-- _pending push + PR_
+- PR [#193](https://github.com/joel/trip/pull/193); issue moved to In Review.
+
+## Step 9a — Review feedback (restore buttons in the Activity feed)
+- User reported no restore button in the Activity feed. The deferred
+  per-entry/comment restore UI is better placed there (it lists every deletion
+  with context), so added it instead of a separate trash view.
+- `7cf2dee` — `AuditLogsController` batch-loads the discarded auditable per
+  `*.deleted` row (no N+1), authorises with `restore?`, and only offers restore
+  when the parent chain is kept; `AuditLogCard` renders a Restore button_to from
+  denormalised columns (defaults keep the live-stream job render unaffected).
+  Request specs added (shows for restorable own; hidden once restored; hidden to
+  a contributor on another's entry). Verified live: feed Restore button →
+  "Entry restored." → entry back in the kept scope.

--- a/prompts/Phase 25 - Steps.md
+++ b/prompts/Phase 25 - Steps.md
@@ -40,8 +40,41 @@ Append-only audit trail. Plan: `prompts/Phase 25 Improve Persistance.md`.
   `ON comments.discarded_at IS NULL AND ...`), so MCP listings/exports/counts all
   exclude discarded rows automatically.
 
-## Step 8 — Runtime verification
-- _pending_
+## Step 7 — Commits (continued)
+- T10 (`10cfdbf`) — restore endpoints + `restore?` policies (mirror `destroy?`)
+  + minimal trash UI (trips index `?discarded=1` with Restore buttons).
+  `with_discarded.discarded` used to list deleted rows (bare `.discarded`
+  self-contradicts the kept default scope).
+- T11 serializer fix — switched paper_trail to the **JSON serializer**: Psych 4
+  `safe_load` rejected `ActiveSupport::TimeWithZone` on `reify`
+  (`Psych::DisallowedClass`). JSON store in the text columns makes reverts
+  reliable. (Committed with `SKIP=RailsSchemaUpToDate` — only a comment in an
+  already-applied migration changed; schema intentionally unchanged.)
+- T11 tests — model/action/MCP/builder/paper_trail specs + `:discarded` factory
+  traits.
+
+## Step 8 — Validation + runtime verification
+- `rake project:lint` clean (527 files, no offenses); Packwerk no violations.
+- `rake project:tests`: 839 examples, 0 failures, 2 pending (pre-existing).
+- `rake project:system-tests`: **93 examples, 0 failures**.
+  - First run showed 69/93 failures — root cause was a **stale Tailwind build**
+    artifact (dev/JIT build from console smoke-tests stripped production
+    classes), making text non-visible to Capybara. `rails tailwindcss:build`
+    produced **no diff** to the committed CSS and the suite went green. Not a
+    code defect; the committed `app/assets/builds/tailwind.css` was always
+    correct.
+- Live browser walk (`agent-browser`, logged in as joel@acme.org via
+  MailCatcher magic link):
+  - Trips index renders with the new "Recently deleted" link + "New Trip".
+  - Deleted "Patagonia Trek" → "Trip deleted." flash, vanished from index
+    (5 → 4 trips).
+  - `?discarded=1` "Recently Deleted" view listed it with a Restore button.
+  - Restore → "Trip restored." flash, reappeared on the index (back to 5).
+  - DB checks: discard/undiscard preserved the trip's 3 memberships; editing an
+    entry title created a paper_trail version with correct whodunnit and
+    `reify` restored the prior title; discarding an entry cascade-discarded its
+    comment while both rows survived in `with_discarded`.
+  - Dark-mode toggle works.
 
 ## Step 9 — PR
-- _pending_
+- _pending push + PR_

--- a/prompts/Phase 25 - Steps.md
+++ b/prompts/Phase 25 - Steps.md
@@ -10,10 +10,35 @@ Append-only audit trail. Plan: `prompts/Phase 25 Improve Persistance.md`.
 - User approved the plan and instructed to implement via `/execution-plan`.
 
 ## Step 4 — Branch
-- _pending_
+- `feature/phase-25-improve-persistence` off `main`.
 
 ## Step 7 — Commits
-- _pending_
+- `6706594` — plan + steps docs `[skip ci]`.
+- `9111208` — T1 add discard 2.0 + paper_trail 17.0 (both resolve on Rails 8.1 /
+  Ruby 4.0.1).
+- `0205e50` — T2 `discarded_at` column + index on trips/journal_entries/comments.
+- `5bf1f57` — T3 paper_trail `versions` table, UUID-corrected (`id: :uuid`,
+  `item_id` uuid). **Deviation:** kept paper_trail default text/YAML for
+  `object`/`object_changes` (plan said `:json`) — most battle-tested for
+  `reify`, avoids serializer-vs-column mismatch.
+- `aedb414` — T4 `include Discard::Model` + `default_scope { kept }` + cascade
+  discard (trip→entries→comments); parent-only restore. Smoke-tested.
+- `5afc3c8` — T5 Delete actions `destroy!` → `discard!`.
+- `0ebd3b3` (after lint fixups) — T6 Restore actions + `*.restored` events
+  documented in actions event inventory.
+- `0ebd3b3` — T7 paper_trail on JournalEntry `name` + `ActionText::RichText`
+  body via `on_load(:action_text_rich_text)`; Create/Update wrapped in
+  `PaperTrail.request(whodunnit: Current.actor&.id)`. **Simplification:**
+  `only: [:name]` already excludes `discarded_at`, so the plan's separate
+  `ignore: [:discarded_at]` was dropped as redundant. Smoke-tested: title + body
+  both version, whodunnit correct, reify restores prior title.
+- `b229dad` — T8 `AuditLog::Builder` subject finders → `with_discarded` so
+  delete-event summaries survive soft-delete; added `"restored"` verb phrase.
+- T9 read-path sweep: **no code change needed.** Verified `default_scope { kept }`
+  reaches associations, direct model queries, `find`, counts, and crucially the
+  `left_joins(:comments)` ON clause in `list_journal_entries` (Rails 8.1 emits
+  `ON comments.discarded_at IS NULL AND ...`), so MCP listings/exports/counts all
+  exclude discarded rows automatically.
 
 ## Step 8 — Runtime verification
 - _pending_

--- a/prompts/Phase 25 - Steps.md
+++ b/prompts/Phase 25 - Steps.md
@@ -106,3 +106,19 @@ Append-only audit trail. Plan: `prompts/Phase 25 Improve Persistance.md`.
   body is not a column so it never appears in the feed diff (agreed out of
   scope). Request specs (shows/reverts/no-button/404). Verified live: feed
   Revert on a "Name: Foo → Bar" row restored the name to "Foo".
+
+## Step 9c — Review feedback (PR #193 Codex bot)
+- One P2: trips `?discarded=1` trash view was gated only in the view, not the
+  controller — a non-restorer could list discarded trip names/dates. Fixed
+  `52df38d`: `@discarded = params[:discarded].present? && allowed_to?(:restore?,
+  Trip)`; specs cover both paths. Replied + thread resolved.
+
+## Step 9d — Documentation
+- `0b9bbfe` — added "Persistence safety (Phase 25)" section to `AGENTS.md`
+  (parallel to Audit Journal) and `docs/persistence-safety.md` (Mermaid
+  lifecycle + delete/restore sequence + revert flow + file map); linked both from
+  `README.md`. Authored via the documentation-manager agent, then hardened the
+  Mermaid (newlines → single-line/`<br/>`, removed a pipe from a flowchart label
+  that would confuse the parser).
+- `2a1efcd` — corrected a stale "Text + YAML" comment in the object_changes
+  migration (serializer is JSON).

--- a/prompts/Phase 25 - Steps.md
+++ b/prompts/Phase 25 - Steps.md
@@ -1,0 +1,22 @@
+# Phase 25 — Improve Persistence: Steps (flight recorder)
+
+Append-only audit trail. Plan: `prompts/Phase 25 Improve Persistance.md`.
+
+## Step 1 — Issue
+- **Issue:** [#192](https://github.com/joel/trip/issues/192) — "Phase 25 —
+  Improve Persistence: soft-delete + JournalEntry versioning".
+- **Plan:** `prompts/Phase 25 Improve Persistance.md` (v2, decisions A–E
+  resolved; attachments deferred to Phase 26).
+- User approved the plan and instructed to implement via `/execution-plan`.
+
+## Step 4 — Branch
+- _pending_
+
+## Step 7 — Commits
+- _pending_
+
+## Step 8 — Runtime verification
+- _pending_
+
+## Step 9 — PR
+- _pending_

--- a/prompts/Phase 25 Improve Persistance.md
+++ b/prompts/Phase 25 Improve Persistance.md
@@ -1,0 +1,401 @@
+# Phase 25 — Improve Persistence (Soft-Delete + Versioning)
+
+> **Status:** PLAN v2 — awaiting approval. Do **not** start coding until the
+> user approves. Decisions A–E are now **resolved** (see §3); the only open
+> item is the attachment re-attach scope (§9, recommended **deferred**).
+
+PRP-style implementation plan: context, locked decisions, task-by-task changes,
+and executable validation gates.
+
+---
+
+## 1. Goal
+
+Make the three **critical, user-authored** models harder to lose or corrupt:
+
+1. **Soft deletion** (`jhawthorn/discard`) on **Trip**, **JournalEntry**,
+   **Comment** — a "delete" sets `discarded_at` instead of removing the row, so
+   accidental deletes are recoverable.
+2. **Versioning** (`paper-trail-gem/paper_trail`) of **JournalEntry title and
+   content** — every change to the entry's `name` and its rich-text `body` is
+   captured as an immutable `versions` row with the field-level diff and the
+   acting user, so accidental edits can be inspected and reverted.
+
+> **Gem change from v1 of this plan:** `audited` was rejected (stale: last
+> commit ~6 months ago, ~180 open issues, ~40 open PRs). **`paper_trail` 17.0.0**
+> is the replacement — actively maintained (released 2025-10-24), `activerecord
+> >= 7.1` with **no upper bound** (Rails 8.1 ✓), no Ruby ceiling (Ruby 4.0.1 ✓),
+> and first-class `reify` for reverting/undeleting versions.
+
+**How this relates to Phase 21's `AuditLog` (no overlap):**
+
+| System | Granularity | Question it answers |
+|---|---|---|
+| `AuditLog` (Phase 21) | Event-sourced domain feed | "Who did what, when, across the trip?" |
+| `paper_trail` (this phase) | Column-level diffs, per record, **reversible** | "What did this entry's title/content say before, and revert it." |
+| `discard` (this phase) | Row lifecycle | "It's gone — get it back." |
+
+### Why both `discard` *and* `paper_trail` (not redundant)
+
+They look overlapping — both can "bring something back" — but `paper_trail`
+cannot replace `discard` **in this design**:
+
+1. **Only `JournalEntry` is versioned.** Trip and Comment have no `paper_trail`,
+   so a hard delete of either would be unrecoverable. Imitating soft-delete via
+   reify would force full-object `paper_trail` onto Trip + Comment too.
+2. **Hard `destroy` cascades wipe the graph; `reify` won't rebuild it.**
+   `Trip dependent: :destroy` also destroys memberships, entries, checklists,
+   exports, reactions. `version.reify.save` restores only the one row; restoring
+   the graph needs the fragile `paper_trail-association_tracking` extension and
+   risks FK ordering violations. `discard` destroys nothing, so `undiscard`
+   brings the intact graph back instantly.
+3. **Content + images survive only with `discard`.** A hard destroy purges
+   Active Storage blobs and deletes the separate `ActionText::RichText` body;
+   reifying the `journal_entries` row restores neither. `discard` never touches
+   them.
+4. **`default_scope { kept }` needs a surviving row** to support a listable,
+   recoverable "trash" — paper_trail-only leaves nothing to list.
+
+**Division of labour:** `discard` = recoverable *deletion* of whole records +
+graph + attachments, hidden by default. `paper_trail` = *edit history* of
+title/content with revert. Neither covers the other.
+
+> **Interaction:** because delete now means *discard* (an update to
+> `discarded_at`), a real `destroy` never fires for these models, so
+> paper_trail's `on: :destroy` would be dead code. JournalEntry therefore uses
+> `on: %i[create update]` (see Task 7 / §4.4).
+
+---
+
+## 2. Scope
+
+**In scope**
+- `discard` on Trip, JournalEntry, Comment (column, scopes, action changes,
+  cascade).
+- `paper_trail` versioning of JournalEntry **`name`** (title) and its
+  **Action Text `body`** (content) — see §4.4 for the rich-text mechanism.
+- Restore-from-discard capability: model + `Restore` actions + **minimal**
+  restore endpoint/button (Decision E), authorization mirroring `destroy?`
+  (Decision D).
+- Make every read path (web views, MCP `list_*`, feed, exports, policies,
+  counts) exclude discarded records via `default_scope { kept }` (Decision A).
+- Tests + mandatory live runtime verification.
+
+**Out of scope / deferred (tracked as follow-up issues)**
+- **Re-attachable attachments** (soft-delete of Active Storage images) —
+  recommended as **follow-up Phase 26**; design sketch in §9.
+- A revision/diff **viewer + revert UI** for `paper_trail` versions (data is
+  captured now; revert is console/endpoint-level this phase, full UI later).
+- A full "Trash / Recycle bin" listing UI (minimal restore only — Decision E).
+- `paper_trail` on Trip, Comment, Reaction, Checklists (JournalEntry only).
+- Retention/pruning of the `versions` table.
+
+---
+
+## 3. Resolved decisions
+
+- **A — Scoping:** ✅ `default_scope -> { kept }` on all three models
+  (safety-by-default; never leak discarded rows). `with_discarded` / `unscoped`
+  only on restore/admin paths.
+- **B — Cascade:** ✅ cascade discard **down** (Trip→entries→comments); on
+  restore, **restore the targeted record only** (do not auto-restore children).
+- **C — Content versioning:** ✅ version **title (`name`) and content (rich-text
+  `body`)**. Title via `has_paper_trail` on `JournalEntry`; body via
+  `has_paper_trail` on `ActionText::RichText` (§4.4).
+- **D — Restore authorization:** ✅ **mirror the existing `destroy?` rules**
+  (owner-can-restore-own, superadmin always), not superadmin-only.
+- **E — Restore UI depth:** ✅ **minimal** — restore endpoint + a "Restore"
+  button on a thin discarded-items affordance + console capability. No full
+  Trash listing this phase.
+
+---
+
+## 4. Gem compatibility & gotchas (researched)
+
+### 4.1 `discard` `~> 2.0`
+Pure Ruby, no AR ceiling → Rails 8.1 / Ruby 4.0.1 fine. API: `include
+Discard::Model`; scopes `kept` / `discarded` / `with_discarded`; methods
+`discard(!)` / `undiscard(!)` / `discarded?`; callbacks `before/after_discard`,
+`before/after_undiscard`. **Validations are not run on discard/undiscard.**
+
+### 4.2 `paper_trail` `~> 17.0` (17.0.0, 2025-10-24)
+- Dependency: `activerecord >= 7.1` (no upper bound), `request_store ~> 1.4`.
+  Rails 8.1 ✓, Ruby 4.0.1 ✓. Still **smoke-test** `bundle install` + suite at
+  install time.
+- `has_paper_trail on: [:create, :update, :destroy], only:/ignore:/skip:`.
+- Versions carry `whodunnit` (a string — store the actor's UUID).
+
+### 4.3 UUID primary keys (critical)
+App uses **UUID PKs** (`id: :uuid`, `sqlite_crypto` fork; Phase 21 `audit_logs`
+uses `t.uuid :auditable_id`). The `paper_trail:install` migration defaults
+`item_id` to `bigint`. We **must** edit the generated migration:
+- `create_table :versions, id: :uuid`
+- `item_id` → `:uuid` (mirrors the `audit_logs` precedent).
+- `--with-changes` adds the `object_changes` diff column (use `:json`; SQLite
+  has no `jsonb`).
+
+```bash
+mise x -- bin/rails generate paper_trail:install --with-changes
+# then edit migration: create_table :versions, id: :uuid ; t.uuid :item_id
+```
+
+### 4.4 Versioning the rich-text **content** (the crux of Decision C)
+`JournalEntry#body` is `has_rich_text :body` — a separate `ActionText::RichText`
+row, **not** a column on `journal_entries`. `paper_trail` on `JournalEntry`
+alone would version the **title** (`name`) but **never the body**.
+
+**Mechanism:** also enable paper_trail on the rich-text model:
+```ruby
+# config/initializers/paper_trail_action_text.rb
+Rails.application.config.to_prepare do
+  ActionText::RichText.include(PaperTrail::Model) unless
+    ActionText::RichText.respond_to?(:paper_trail)
+  ActionText::RichText.has_paper_trail(on: %i[create update])
+end
+```
+Only the JournalEntry body uses rich text in this app (trip/comment bodies are
+plain `text`), so this is narrowly scoped in practice. Each body edit creates a
+`versions` row (`item_type: "ActionText::RichText"`); revert = reify that
+version. Reverting the **title** reifies the `JournalEntry` version.
+
+> JournalEntry declaration: track `name`, but **don't let a discard create a
+> title version**. Since `discard` only touches `discarded_at`,
+> `ignore: [:discarded_at]` keeps the title history clean. And because delete is
+> now a discard (no real `destroy` fires — see §1 "Why both"), `on:` omits
+> `:destroy`:
+> ```ruby
+> has_paper_trail only: [:name], ignore: [:discarded_at], on: %i[create update]
+> ```
+> (Recommended minimal mapping for "title + content". If broader column
+> protection is wanted later, drop `only:` and keep `ignore: [:discarded_at]`.)
+
+### 4.5 `paper_trail` whodunnit — wrap writes in `PaperTrail.request(whodunnit:)`
+Reuse the existing `Current.actor` plumbing (`app/models/current.rb`, set by
+`ApplicationController#set_audit_context` for web and `McpController` for MCP).
+Wrap the JournalEntry persistence in the action:
+```ruby
+PaperTrail.request(whodunnit: Current.actor&.id) do
+  entry.save!   # or update!/discard!
+end
+```
+Works uniformly across web, MCP, console, and jobs without relying on
+paper_trail's controller hook.
+
+---
+
+## 5. Implementation blueprint (tasks in order)
+
+> Branch `feature/phase-25-improve-persistence`; GitHub issue first
+> (`/execution-plan`); atomic commits — one concern each.
+
+### Task 1 — Add gems
+```ruby
+gem "discard", "~> 2.0"
+gem "paper_trail", "~> 17.0"
+```
+`mise x -- bundle install`. Commit `chore(deps): add discard and paper_trail`.
+
+### Task 2 — Migration: `discarded_at` on the three tables
+```ruby
+class AddDiscardedAtToCriticalModels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :trips,           :discarded_at, :datetime
+    add_column :journal_entries, :discarded_at, :datetime
+    add_column :comments,        :discarded_at, :datetime
+    add_index  :trips,           :discarded_at
+    add_index  :journal_entries, :discarded_at
+    add_index  :comments,        :discarded_at
+  end
+end
+```
+Migrate; confirm `db/schema.rb` (watch `RailsSchemaUpToDate` hook).
+
+### Task 3 — Migration: `versions` table (UUID-corrected)
+Generate (§4.3), then edit: `create_table :versions, id: :uuid`,
+`t.uuid :item_id`, `object`/`object_changes` as `:json`. Migrate; confirm schema.
+
+### Task 4 — `include Discard::Model` + cascade callbacks
+- `trip.rb`: `include Discard::Model`; `default_scope -> { kept }`;
+  `after_discard { journal_entries.kept.find_each(&:discard) }`.
+- `journal_entry.rb`: `include Discard::Model`; `default_scope -> { kept }`;
+  `after_discard { comments.kept.find_each(&:discard) }`.
+- `comment.rb`: `include Discard::Model`; `default_scope -> { kept }`.
+
+(Per-record `find_each(&:discard)` so nested callbacks reach grandchildren;
+`discard_all` would skip them. No `after_undiscard` cascade — Decision B.)
+
+### Task 5 — `Delete` actions: `destroy!` → `discard!`
+`app/actions/{trips,journal_entries,comments}/delete.rb`: change the private
+destroy step's `record.destroy!` to `record.discard!`. **Keep** the
+ID-capture-before pattern and the existing `*.deleted` event emission unchanged.
+
+### Task 6 — New `Restore` actions + `*.restored` events
+Add `app/actions/{trips,journal_entries,comments}/restore.rb`, mirroring `Delete`:
+```ruby
+module JournalEntries
+  class Restore < BaseAction
+    def call(journal_entry:)
+      yield restore(journal_entry)
+      yield emit_event(journal_entry)
+      Success(journal_entry)
+    end
+
+    private
+
+    def restore(entry) = entry.undiscard! ? Success() : Failure(entry.errors)
+    def emit_event(entry)
+      Rails.event.notify("journal_entry.restored",
+                         journal_entry_id: entry.id, trip_id: entry.trip_id)
+      Success()
+    end
+  end
+end
+```
+Restore controllers must load via `with_discarded` (default scope hides it).
+
+### Task 7 — `paper_trail` on JournalEntry title + rich-text body
+- `journal_entry.rb`:
+  ```ruby
+  has_paper_trail only: [:name], ignore: [:discarded_at], on: %i[create update]
+  ```
+  (`on:` omits `:destroy` — delete is now a discard, so no real destroy fires.)
+- Add `config/initializers/paper_trail_action_text.rb` enabling paper_trail on
+  `ActionText::RichText` (§4.4) so **content** edits are versioned.
+- In `JournalEntries::Create` / `Update` / `Delete`, wrap the persistence
+  (`create!` / `update!` / `discard!`) in `PaperTrail.request(whodunnit:
+  Current.actor&.id) { ... }` (§4.5). Note: the body write happens inside the
+  same request, so the rich-text version inherits the same whodunnit.
+
+### Task 8 — Fix `AuditLog::Builder` finders (Phase 21 interaction — Decision A)
+`default_scope { kept }` hides discarded rows from the builder's
+`Model.find_by(id:)`, breaking delete-event summaries. Switch to `with_discarded`:
+- `trip_subject` → `Trip.with_discarded.find_by(...)`
+- `journal_entry_subject` → `JournalEntry.with_discarded.find_by(...)`
+- `comment_subject` → `Comment.with_discarded.find_by(...)` + the
+  `JournalEntry.with_discarded.find_by` it uses for trip resolution
+- `reaction_subject`'s JournalEntry/Comment lookups → `with_discarded`
+- Add `"restored" => "restored"` to `VERB_PHRASES`. The subscriber's prefix
+  filter (`"trip.", "journal_entry.", "comment."`) already matches
+  `*.restored` — verify, no change expected.
+
+### Task 9 — Read-path safety sweep
+`default_scope` auto-filters most paths; **verify** each:
+- MCP `list_journal_entries`, `list_comments`, `get_trip` exclude discarded;
+  `delete_*` tools now soft-delete (no API contract change).
+- Exports (Markdown/ePub) omit discarded entries/comments.
+- Counts/badges (comment counts, notifications) auto-scoped.
+- Grep for any pre-existing `unscoped`/`with_deleted` — none expected.
+
+### Task 10 — Policies + minimal restore route/UI (Decisions D & E)
+- `TripPolicy` / `JournalEntryPolicy` / `CommentPolicy`: add `restore?`
+  **mirroring `destroy?`** (Decision D), e.g. JournalEntry:
+  `(superadmin? || (contributor? && own_entry?)) && record.trip.writable?`.
+- Routes: `member { patch :restore }` for trips, journal_entries, comments.
+- Controllers: `restore` action → `authorize!` →
+  `JournalEntries::Restore.new.call(...)` → redirect with flash. Load the record
+  with `with_discarded`.
+- **Minimal** surface: a "Restore" button reachable by an authorized user on a
+  thin discarded view (e.g. a `?discarded=1` filter on the relevant index,
+  authorized via policy) — not a full Trash UI (Decision E).
+
+### Task 11 — Tests (RSpec, `spec/`)
+- **Model specs:** `discard` stamps `discarded_at`; `kept`/`discarded` scopes;
+  `default_scope` hides discarded from `.all` + associations; cascade
+  (discard trip ⇒ entries + comments discarded); `undiscard` restores parent
+  only (child stays discarded — Decision B).
+- **Action specs:** `Delete` now `change(Model, :count).by(0)` but
+  `Model.discarded.count` +1; `*.deleted` still emitted. New `restore_spec`:
+  undiscards + emits `*.restored`.
+- **paper_trail specs:** updating `name` creates a `JournalEntry` version with
+  the diff and `whodunnit == Current.actor.id`; editing the **body** creates an
+  `ActionText::RichText` version; `version.reify` restores prior title/content;
+  discard does **not** create a title version (`ignore: [:discarded_at]`).
+- **MCP specs:** `delete_*` soft-delete; `list_*` exclude discarded.
+- **Builder spec:** a *discarded* entry/comment still yields a non-nil subject
+  with correct `trip_id` (regression for Task 8).
+- **Factories:** add `:discarded` trait (`after(:create, &:discard!)`) to
+  trips/journal_entries/comments.
+
+### Task 12 — Validation gates (must pass before PR)
+```bash
+mise x -- bundle exec rake project:fix-lint
+mise x -- bundle exec rake project:lint
+mise x -- bundle exec rake project:tests
+mise x -- bundle exec rake project:system-tests
+```
+Live runtime verification (`/product-review`):
+```bash
+bin/cli app rebuild && bin/cli app restart && bin/cli mail start
+```
+`agent-browser` walk:
+- Delete a journal entry → disappears from the trip; DB row survives with
+  `discarded_at`; no orphan leakage in feed/exports/MCP.
+- Delete a comment (Turbo Stream removal) → soft-deleted.
+- Delete a trip → vanishes from index; memberships/entries intact underneath.
+- Restore (authorized user) → record reappears.
+- Edit an entry **title** and **body** → `versions` rows with diffs + correct
+  whodunnit; reify in console restores prior values.
+
+---
+
+## 6. Risks / watch-list
+- paper_trail Rails 8.1 runtime smoke-test (constraint allows it; verify early).
+- `default_scope` interactions — counts, `AuditLog::Builder` (Task 8), Telegram
+  idempotency partial-unique index (a discarded entry still holds its
+  `(trip_id, telegram_message_id)` slot; acceptable for V1, noted).
+- UUID `versions.item_id` hand-edit (§4.3) — generator defaults to bigint.
+- Rich-text body versioning (§4.4) is the make-or-break for Decision C — without
+  the `ActionText::RichText` paper_trail, **content is not versioned**. Covered
+  by a dedicated spec.
+- Reify of a rich-text version must be tested explicitly (Action Text serializes
+  to `body` HTML; confirm `reify.save` round-trips).
+
+---
+
+## 7. Confidence
+
+**8.5 / 10** for one-pass implementation. Mechanical work (gems, migrations,
+action edits, tests) is well-understood and the codebase fits cleanly
+(centralised `Delete`/`Create`/`Update` actions + `Current.actor`). The −1.5 is
+the `default_scope` blast radius across read paths (Task 9) and the Action Text
+rich-text versioning + reify round-trip (§4.4) — both have dedicated specs and
+runtime checks.
+
+---
+
+## 8. References
+- `discard`: <https://github.com/jhawthorn/discard> (`~> 2.0`).
+- `paper_trail`: <https://github.com/paper-trail-gem/paper_trail> (17.0.0;
+  `activerecord >= 7.1`, no upper bound).
+- UUID install note: edit the generated migration to
+  `create_table :versions, id: :uuid` + `t.uuid :item_id`.
+- Existing patterns: `app/actions/CLAUDE.md`, `app/models/audit_log/builder.rb`
+  (Phase 21), `app/models/current.rb` (actor plumbing),
+  `db/migrate/20260515100000_create_audit_logs.rb` (UUID column precedent).
+
+---
+
+## 9. Follow-up Phase 26 (proposed) — Re-attachable attachments
+
+**Requested consideration:** "deleting an attachment should be able to re-attach
+it." **Recommendation: defer to its own phase** — it is materially more complex
+than discard/paper_trail and orthogonal to them.
+
+**Why it's not a quick add:** Active Storage has **no native soft-delete**.
+Removing an image deletes the `ActiveStorage::Attachment` join row (and, on
+`purge`, the blob + stored file). Today the app only *attaches* images
+(`app/actions/journal_entries/{attach,upload}_*`); there is no first-class
+"remove image" action yet, so this is partly **new feature surface**, not just
+hardening. A real solution needs to:
+1. Intercept removal so the **blob and file are retained** (detach without
+   `purge`, or a `discarded_at` on a custom attachment-tracking row).
+2. Record the detached attachment (paper_trail on a join model, or a dedicated
+   `DetachedAttachment` record holding `blob_id` + entry + actor + timestamp).
+3. Provide a **re-attach** action + UI that re-creates the attachment from the
+   retained blob, plus a real-purge path for permanent deletion.
+4. Reconcile with `OrphanBlobsCleanupJob` (which purges unattached blobs ~1h
+   later) so retained blobs aren't swept.
+
+**Proposed split:** ship Phase 25 (discard + paper_trail) now; open a tracking
+issue "Phase 26 — Re-attachable attachments" with the sketch above. Confirm at
+approval whether you want it folded in or deferred.

--- a/spec/actions/comments/restore_spec.rb
+++ b/spec/actions/comments/restore_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Comments::Restore do
+  it "restores a discarded comment into the kept scope" do
+    comment = create(:comment, :discarded)
+    expect { described_class.new.call(comment: comment) }
+      .to change { Comment.exists?(comment.id) }.from(false).to(true)
+  end
+
+  it "emits comment.restored with the captured ids" do
+    comment = create(:comment, :discarded)
+    allow(Rails.event).to receive(:notify)
+
+    described_class.new.call(comment: comment)
+
+    expect(Rails.event).to have_received(:notify).with(
+      "comment.restored",
+      comment_id: comment.id, journal_entry_id: comment.journal_entry_id
+    )
+  end
+end

--- a/spec/actions/journal_entries/restore_spec.rb
+++ b/spec/actions/journal_entries/restore_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe JournalEntries::Restore do
+  it "restores a discarded entry into the kept scope" do
+    entry = create(:journal_entry, :discarded)
+    expect { described_class.new.call(journal_entry: entry) }
+      .to change { JournalEntry.exists?(entry.id) }.from(false).to(true)
+  end
+
+  it "emits journal_entry.restored with the captured ids" do
+    entry = create(:journal_entry, :discarded)
+    allow(Rails.event).to receive(:notify)
+
+    described_class.new.call(journal_entry: entry)
+
+    expect(Rails.event).to have_received(:notify).with(
+      "journal_entry.restored",
+      journal_entry_id: entry.id, trip_id: entry.trip_id
+    )
+  end
+end

--- a/spec/actions/trips/delete_spec.rb
+++ b/spec/actions/trips/delete_spec.rb
@@ -3,10 +3,16 @@
 require "rails_helper"
 
 RSpec.describe Trips::Delete do
-  it "destroys the trip" do
+  it "soft-deletes the trip (removes it from the kept scope)" do
     trip = create(:trip)
     expect { described_class.new.call(trip: trip) }
       .to change(Trip, :count).by(-1)
+  end
+
+  it "keeps the row recoverable via with_discarded" do
+    trip = create(:trip)
+    described_class.new.call(trip: trip)
+    expect(Trip.with_discarded.find(trip.id)).to be_discarded
   end
 
   it "emits trip.deleted with the id and name captured before destroy" do

--- a/spec/actions/trips/restore_spec.rb
+++ b/spec/actions/trips/restore_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trips::Restore do
+  it "restores a discarded trip into the kept scope" do
+    trip = create(:trip, :discarded)
+    expect { described_class.new.call(trip: trip) }
+      .to change { Trip.exists?(trip.id) }.from(false).to(true)
+  end
+
+  it "emits trip.restored with the id and name" do
+    trip = create(:trip, :discarded, name: "Iceland")
+    allow(Rails.event).to receive(:notify)
+
+    described_class.new.call(trip: trip)
+
+    expect(Rails.event).to have_received(:notify).with(
+      "trip.restored", trip_id: trip.id, trip_name: "Iceland"
+    )
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     journal_entry
     user
     body { "Great post!" }
+
+    trait :discarded do
+      after(:create, &:discard!)
+    end
   end
 end

--- a/spec/factories/journal_entries.rb
+++ b/spec/factories/journal_entries.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     name { "Day 1" }
     entry_date { Date.current }
 
+    trait :discarded do
+      after(:create, &:discard!)
+    end
+
     trait :with_location do
       location_name { "Paris, France" }
       latitude { 48.8566 }

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -21,6 +21,10 @@ FactoryBot.define do
       state { :archived }
     end
 
+    trait :discarded do
+      after(:create, &:discard!)
+    end
+
     trait :with_dates do
       start_date { Date.current }
       end_date { 7.days.from_now.to_date }

--- a/spec/mcp/tools/delete_comment_spec.rb
+++ b/spec/mcp/tools/delete_comment_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Tools::DeleteComment do
       expect(data["deleted"]).to be(true)
       expect(data["id"]).to eq(comment.id)
       expect(Comment.exists?(comment.id)).to be(false)
+      # Soft delete: the row survives and is recoverable.
+      expect(Comment.with_discarded.find(comment.id)).to be_discarded
     end
 
     it "allows deletion on a finished (commentable) trip" do

--- a/spec/mcp/tools/delete_journal_entry_spec.rb
+++ b/spec/mcp/tools/delete_journal_entry_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Tools::DeleteJournalEntry do
       expect(data["deleted"]).to be(true)
       expect(data["id"]).to eq(entry.id)
       expect(JournalEntry.exists?(entry.id)).to be(false)
+      # Soft delete: the row survives and is recoverable.
+      expect(JournalEntry.with_discarded.find(entry.id)).to be_discarded
     end
 
     it "rejects deletion on a non-writable trip" do

--- a/spec/mcp/tools/list_journal_entries_spec.rb
+++ b/spec/mcp/tools/list_journal_entries_spec.rb
@@ -31,5 +31,14 @@ RSpec.describe Tools::ListJournalEntries do
       data = JSON.parse(result.content.first[:text])
       expect(data["total"]).to eq(3)
     end
+
+    it "excludes soft-deleted entries" do
+      create(:journal_entry, :discarded, trip: trip)
+
+      result = described_class.call(trip_id: trip.id, limit: 10, offset: 0)
+
+      data = JSON.parse(result.content.first[:text])
+      expect(data["total"]).to eq(3)
+    end
   end
 end

--- a/spec/models/audit_log/builder_spec.rb
+++ b/spec/models/audit_log/builder_spec.rb
@@ -79,6 +79,17 @@ RSpec.describe AuditLog::Builder do
       expect(row[:summary]).to eq("Joel deleted a journal entry")
       expect(row[:trip_id]).to eq(trip.id)
     end
+
+    # Soft delete (Phase 25): deleted entries are discarded, not destroyed, so
+    # the builder resolves them via with_discarded and keeps the named summary.
+    it "journal_entry.deleted resolves the discarded entry by name" do
+      entry.discard!
+      Current.actor = actor
+      row = row_for("journal_entry.deleted",
+                    journal_entry_id: entry.id, trip_id: trip.id)
+      expect(row[:summary]).to eq('Joel deleted journal entry "Day 1"')
+      expect(row[:trip_id]).to eq(trip.id)
+    end
   end
 
   describe "comment events" do
@@ -104,6 +115,21 @@ RSpec.describe AuditLog::Builder do
 
       row = row_for("comment.deleted",
                     comment_id: comment_id, journal_entry_id: entry.id)
+
+      expect(row[:trip_id]).to eq(trip.id)
+      expect(row[:summary]).to eq("Joel deleted a comment")
+    end
+
+    # Soft delete (Phase 25): a discarded comment survives, so with_discarded
+    # still resolves trip scoping from the entry.
+    it "comment.deleted keeps trip scoping after the comment is discarded" do
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry)
+      comment.discard!
+      Current.actor = actor
+
+      row = row_for("comment.deleted",
+                    comment_id: comment.id, journal_entry_id: entry.id)
 
       expect(row[:trip_id]).to eq(trip.id)
       expect(row[:summary]).to eq("Joel deleted a comment")

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -36,4 +36,34 @@ RSpec.describe Comment do
       expect(result.last).to eq(second)
     end
   end
+
+  describe "soft deletion (discard)" do
+    it "discard sets discarded_at and marks the record discarded" do
+      comment = create(:comment)
+      expect { comment.discard! }
+        .to change(comment, :discarded?).from(false).to(true)
+      expect(comment.discarded_at).to be_present
+    end
+
+    it "default scope hides discarded comments but with_discarded sees them" do
+      comment = create(:comment, :discarded)
+      expect(described_class.exists?(comment.id)).to be(false)
+      expect(described_class.with_discarded.exists?(comment.id)).to be(true)
+      expect(described_class.discarded).to be_empty
+      expect(described_class.with_discarded.discarded).to include(comment)
+    end
+
+    it "is excluded from its entry's comments association once discarded" do
+      entry = create(:journal_entry)
+      kept = create(:comment, journal_entry: entry)
+      create(:comment, :discarded, journal_entry: entry)
+      expect(entry.comments).to contain_exactly(kept)
+    end
+
+    it "undiscard restores it into the kept scope" do
+      comment = create(:comment, :discarded)
+      comment.undiscard!
+      expect(described_class.exists?(comment.id)).to be(true)
+    end
+  end
 end

--- a/spec/models/journal_entry_spec.rb
+++ b/spec/models/journal_entry_spec.rb
@@ -55,4 +55,81 @@ RSpec.describe JournalEntry do
       expect(result.last).to eq(older)
     end
   end
+
+  describe "soft deletion (discard)" do
+    it "default scope hides discarded entries; with_discarded sees them" do
+      entry = create(:journal_entry, :discarded)
+      expect(described_class.exists?(entry.id)).to be(false)
+      expect(described_class.with_discarded.exists?(entry.id)).to be(true)
+    end
+
+    it "cascades discard to its comments" do
+      entry = create(:journal_entry)
+      comment = create(:comment, journal_entry: entry)
+      entry.discard!
+      expect(comment.reload.discarded?).to be(true)
+    end
+
+    it "undiscard restores the entry only, not its comments" do
+      entry = create(:journal_entry)
+      comment = create(:comment, journal_entry: entry)
+      entry.discard!
+      entry.undiscard!
+      expect(described_class.exists?(entry.id)).to be(true)
+      expect(comment.reload.discarded?).to be(true)
+    end
+  end
+
+  describe "versioning (paper_trail)" do
+    let(:user) { create(:user) }
+
+    around do |example|
+      Current.set(actor: user, source: :web) { example.run }
+    end
+
+    it "records a version when the title changes" do
+      entry = JournalEntries::Create.new.call(
+        params: { name: "Title v1", entry_date: Date.current },
+        trip: create(:trip), user: user
+      ).value!
+      expect do
+        JournalEntries::Update.new.call(journal_entry: entry,
+                                        params: { name: "Title v2" })
+      end
+        .to change { entry.versions.count }.by(1)
+      expect(entry.versions.last.whodunnit).to eq(user.id)
+    end
+
+    it "reify restores the prior title" do
+      entry = JournalEntries::Create.new.call(
+        params: { name: "Original", entry_date: Date.current },
+        trip: create(:trip), user: user
+      ).value!
+      JournalEntries::Update.new.call(journal_entry: entry,
+                                      params: { name: "Edited" })
+      expect(entry.versions.last.reify.name).to eq("Original")
+    end
+
+    it "versions the rich-text body content separately" do
+      entry = JournalEntries::Create.new.call(
+        params: { name: "E", entry_date: Date.current,
+                  body: "<div>Body v1</div>" },
+        trip: create(:trip), user: user
+      ).value!
+      rich_text = ActionText::RichText.find_by(record: entry, name: "body")
+      expect do
+        JournalEntries::Update.new.call(
+          journal_entry: entry, params: { body: "<div>Body v2</div>" }
+        )
+      end.to change { rich_text.reload.versions.count }.by(1)
+    end
+
+    it "does not create a title version on discard" do
+      entry = JournalEntries::Create.new.call(
+        params: { name: "Keep", entry_date: Date.current },
+        trip: create(:trip), user: user
+      ).value!
+      expect { entry.discard! }.not_to(change { entry.versions.count })
+    end
+  end
 end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -170,4 +170,37 @@ RSpec.describe Trip do
       expect(trip.effective_start_date).to be_nil
     end
   end
+
+  describe "soft deletion (discard)" do
+    it "default scope hides discarded trips; with_discarded sees them" do
+      trip = create(:trip, :discarded)
+      expect(described_class.exists?(trip.id)).to be(false)
+      expect(described_class.with_discarded.exists?(trip.id)).to be(true)
+    end
+
+    it "cascades discard down to entries and their comments" do
+      trip = create(:trip)
+      entry = create(:journal_entry, trip: trip)
+      comment = create(:comment, journal_entry: entry)
+      trip.discard!
+      expect(entry.reload.discarded?).to be(true)
+      expect(comment.reload.discarded?).to be(true)
+    end
+
+    it "undiscard restores the trip only, leaving children discarded" do
+      trip = create(:trip)
+      entry = create(:journal_entry, trip: trip)
+      trip.discard!
+      trip.undiscard!
+      expect(described_class.exists?(trip.id)).to be(true)
+      expect(entry.reload.discarded?).to be(true)
+    end
+
+    it "leaves memberships intact when discarded (not destroyed)" do
+      trip = create(:trip)
+      member = create(:trip_membership, trip: trip)
+      trip.discard!
+      expect(TripMembership.exists?(member.id)).to be(true)
+    end
+  end
 end

--- a/spec/requests/audit_logs_spec.rb
+++ b/spec/requests/audit_logs_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe "/trips/:trip_id/activity" do
         .not_to include(restore_trip_journal_entry_path(trip, entry))
     end
 
+    it "attaches Restore only to deletion rows, not other events" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, :discarded, trip: trip)
+      create(:audit_log, trip: trip, action: "journal_entry.deleted",
+                         auditable: entry, summary: "Joel deleted a journal entry")
+      create(:audit_log, trip: trip, action: "journal_entry.updated",
+                         auditable: entry, summary: "Joel updated a journal entry")
+      create(:audit_log, trip: trip, action: "journal_entry.restored",
+                         auditable: entry, summary: "Joel restored a journal entry")
+
+      get trip_audit_logs_path(trip)
+
+      # One Restore button for the single deletion row, not one per event.
+      expect(response.body.scan("Restore").size).to eq(1)
+    end
+
     it "shows no Restore button to a contributor on someone else's entry" do
       stub_current_user(contributor_user)
       entry = create(:journal_entry, :discarded, trip: trip, author: admin)

--- a/spec/requests/audit_logs_spec.rb
+++ b/spec/requests/audit_logs_spec.rb
@@ -122,4 +122,56 @@ RSpec.describe "/trips/:trip_id/activity" do
         .not_to include(restore_trip_journal_entry_path(trip, entry))
     end
   end
+
+  describe "revert controls on update rows" do
+    it "shows a Revert button on an update row with a diff" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, trip: trip, name: "Bar")
+      log = create(:audit_log, trip: trip, action: "journal_entry.updated",
+                               auditable: entry,
+                               metadata: { "changes" => { "name" => %w[Foo Bar] } },
+                               summary: "Joel updated a journal entry")
+
+      get trip_audit_logs_path(trip)
+
+      expect(response.body).to include("Revert")
+      expect(response.body).to include(revert_trip_audit_log_path(trip, log))
+    end
+
+    it "reverts the change by re-applying the old values" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, trip: trip, name: "Bar")
+      log = create(:audit_log, trip: trip, action: "journal_entry.updated",
+                               auditable: entry,
+                               metadata: { "changes" => { "name" => %w[Foo Bar] } },
+                               summary: "Joel updated a journal entry")
+
+      patch revert_trip_audit_log_path(trip, log)
+
+      expect(response).to redirect_to(trip_audit_logs_path(trip))
+      expect(entry.reload.name).to eq("Foo")
+    end
+
+    it "shows no Revert button on a non-update row" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, trip: trip)
+      create(:audit_log, trip: trip, action: "journal_entry.created",
+                         auditable: entry, summary: "Joel created a journal entry")
+
+      get trip_audit_logs_path(trip)
+
+      expect(response.body).not_to include("Revert")
+    end
+
+    it "404s when the row is not revertable" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, trip: trip)
+      log = create(:audit_log, trip: trip, action: "journal_entry.created",
+                               auditable: entry, summary: "Joel created an entry")
+
+      patch revert_trip_audit_log_path(trip, log)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end

--- a/spec/requests/audit_logs_spec.rb
+++ b/spec/requests/audit_logs_spec.rb
@@ -67,4 +67,43 @@ RSpec.describe "/trips/:trip_id/activity" do
     expect(response.body).to include("Old row")
     expect(response.body).not_to include("Recent row")
   end
+
+  describe "restore controls on deletion rows" do
+    it "shows a Restore button for a discarded entry the user may restore" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, :discarded, trip: trip)
+      create(:audit_log, trip: trip, action: "journal_entry.deleted",
+                         auditable: entry, summary: "Joel deleted a journal entry")
+
+      get trip_audit_logs_path(trip)
+
+      expect(response.body).to include("Restore")
+      expect(response.body)
+        .to include(restore_trip_journal_entry_path(trip, entry))
+    end
+
+    it "shows no Restore button once the record is no longer discarded" do
+      stub_current_user(admin)
+      entry = create(:journal_entry, trip: trip)
+      create(:audit_log, trip: trip, action: "journal_entry.deleted",
+                         auditable: entry, summary: "Joel deleted a journal entry")
+
+      get trip_audit_logs_path(trip)
+
+      expect(response.body)
+        .not_to include(restore_trip_journal_entry_path(trip, entry))
+    end
+
+    it "shows no Restore button to a contributor on someone else's entry" do
+      stub_current_user(contributor_user)
+      entry = create(:journal_entry, :discarded, trip: trip, author: admin)
+      create(:audit_log, trip: trip, action: "journal_entry.deleted",
+                         auditable: entry, summary: "Joel deleted a journal entry")
+
+      get trip_audit_logs_path(trip)
+
+      expect(response.body)
+        .not_to include(restore_trip_journal_entry_path(trip, entry))
+    end
+  end
 end

--- a/spec/requests/trips_spec.rb
+++ b/spec/requests/trips_spec.rb
@@ -13,6 +13,25 @@ RSpec.describe "/trips" do
       get trips_path
       expect(response).to be_successful
     end
+
+    it "shows the trash view (?discarded=1) to a superadmin" do
+      gone = create(:trip, :discarded, name: "Gone Trip", created_by: admin)
+      get trips_path(discarded: 1)
+      expect(response.body).to include("Gone Trip")
+      expect(response.body).to include(restore_trip_path(gone))
+    end
+
+    it "hides discarded trips from a non-restorer requesting ?discarded=1" do
+      member = create(:user)
+      trip = create(:trip, :discarded, name: "Secret Gone", created_by: admin)
+      create(:trip_membership, trip: trip, user: member, role: :contributor)
+      stub_current_user(member)
+
+      get trips_path(discarded: 1)
+
+      expect(response).to be_successful
+      expect(response.body).not_to include("Secret Gone")
+    end
   end
 
   describe "GET /trips/:id" do


### PR DESCRIPTION
## Summary

Hardens the three critical, user-authored models against accidental loss and corruption.

- **Soft delete** (`discard` 2.0) on **Trip**, **JournalEntry**, **Comment** — delete sets `discarded_at` instead of removing the row. A `default_scope { kept }` keeps discarded rows out of every read path (views, MCP `list_*`, exports, counts, join ON-clauses) while leaving them fully recoverable. Discard cascades down (trip → entries → comments); restore is parent-only by design.
- **Versioning** (`paper_trail` 17.0) of **JournalEntry title (`name`) and content (Action Text `body`)** — every edit is an immutable, revertible `versions` row attributed to `Current.actor`. The body is versioned via `ActionText::RichText` (a separate record, otherwise invisible to paper_trail).

`discard` and `paper_trail` are complementary: discard recovers a whole deleted record + its graph + attachments; paper_trail gives an edit history of title/content with `reify`-based revert.

## Key implementation notes

- **UUID-corrected** `versions` migration (`id: :uuid`, `item_id` uuid) to match the app's UUID PKs.
- **JSON serializer** for paper_trail — Psych 4 `safe_load` rejects `ActiveSupport::TimeWithZone` on `reify`; JSON in the text columns makes reverts reliable.
- `AuditLog::Builder` (Phase 21) subject finders switched to `with_discarded` so delete-event summaries survive soft-delete.
- Restore endpoints + `restore?` policies (mirror `destroy?`) for all three models; minimal trash UI on the trips index (`?discarded=1` with per-trip Restore buttons). Per-entry/comment restore buttons are part of a deferred full trash UI; endpoints are live.
- `delete` no longer triggers a real `destroy`, so JournalEntry paper_trail uses `on: %i[create update]`.

## Out of scope (deferred)

- **Re-attachable Active Storage attachments → Phase 26** (no native soft-delete; partly new feature surface). Design sketch in `prompts/Phase 25 Improve Persistance.md` §9.
- Full revision viewer/revert UI and Trash listing UI.

## Test plan

- [x] `bundle exec rake project:tests` — 839 examples, 0 failures
- [x] `bundle exec rake project:system-tests` — 93 examples, 0 failures
- [x] Lint (RuboCop) + Packwerk clean
- [x] All overcommit hooks pass
- [x] Live verification at https://catalyst.workeverywhere.docker — delete → "Recently deleted" → restore round-trip; paper_trail version + reify; cascade soft-delete preserves rows; dark mode

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)