### PR TITLE
Phase 25 follow-up: document Restore actions + re-trigger main CI/Deploy

### DIFF
--- a/app/actions/comments/restore.rb
+++ b/app/actions/comments/restore.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Comments
+  # Restores a soft-deleted comment: undiscards it into the kept scope and emits
+  # "comment.restored". Resolve the comment via `with_discarded` first (the
+  # default kept scope hides it); its parent entry must be kept for the comment
+  # to be visible once restored. Returns Failure(message) if it is not discarded.
   class Restore < BaseAction
     def call(comment:)
       yield restore(comment)

--- a/app/actions/journal_entries/restore.rb
+++ b/app/actions/journal_entries/restore.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module JournalEntries
+  # Restores a soft-deleted journal entry: undiscards it into the kept scope and
+  # emits "journal_entry.restored". Parent-only — restoring an entry does not
+  # auto-restore comments that were discarded with it. Load the entry via
+  # `with_discarded` first (the default kept scope hides it). Returns
+  # Failure(message) if it is not discarded.
   class Restore < BaseAction
     def call(journal_entry:)
       yield restore(journal_entry)

--- a/app/actions/trips/restore.rb
+++ b/app/actions/trips/restore.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 module Trips
+  # Restores a soft-deleted trip: undiscards it into the kept scope and emits
+  # "trip.restored". Restore is parent-only by design — it mirrors the down-only
+  # discard cascade, so a trip's previously discarded entries are not
+  # auto-resurrected. Load the trip via `Trip.with_discarded` first (the default
+  # kept scope hides it). Returns Failure(message) if it is not discarded.
   class Restore < BaseAction
     def call(trip:)
       yield restore(trip)

--- a/docs/persistence-safety.md
+++ b/docs/persistence-safety.md
@@ -117,6 +117,17 @@ dates and comment body. The journal-entry **rich-text body is not a column**, so
 it never appears in the feed diff and is intentionally out of scope for Revert
 (its history lives in `paper_trail` on `ActionText::RichText` instead).
 
+### Where users reach these
+
+- **Restore a deleted trip:** the trips index trash view — `/trips?discarded=1`
+  ("Recently deleted"), superadmin-only, with a per-trip Restore button.
+- **Restore a deleted entry/comment, or revert an edit:** the trip **Activity
+  feed** (`/trips/:id/activity`) — a Restore button on `*.deleted` rows and a
+  Revert button on `*.updated` rows, each shown only to users the policy allows.
+
+Every button is authorised server-side (`restore?` / `update?`), not merely
+hidden in the view.
+
 ---
 
 ## 3. Gotchas / rules


### PR DESCRIPTION
## Summary

#193 (Phase 25) was rebase-and-merged, but the merge push to `main` carried intermediate `[skip ci]` commits, so GitHub skipped **both CI and Deploy** — `main` has no green run and Phase 25 was never deployed.

This small PR re-triggers `main` CI + Deploy with a clean push (no `[skip ci]`), and improves docs along the way:

- Class docstrings on `Trips::Restore`, `JournalEntries::Restore`, `Comments::Restore` (undiscard! + `*.restored` event, parent-only down-only-cascade semantics, load via `with_discarded`).
- A "Where users reach these" note in `docs/persistence-safety.md` (trips trash view + Activity feed restore/revert).

It touches `.rb` files (not in `ci.yml`'s `paths-ignore`), so CI runs on this PR and on the merge to `main`; `deploy.yml` (no `paths-ignore`) deploys Phase 25 on merge.

## Test plan
- [x] RuboCop clean
- [x] Restore action specs pass (6 examples)
- [x] CI fires on this PR (pull_request) — comment-only `.rb` changes
- [ ] On merge: `main` CI + Deploy run green (enables the `phase-25` tag)

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)