### PR TITLE
Run the app in production mode locally: orchestrate SeaweedFS + bucket host

### DIFF
--- a/bin/cli-files/app-cmd/app_service.rb
+++ b/bin/cli-files/app-cmd/app_service.rb
@@ -244,14 +244,16 @@ module AppCLI
 
       def network_flags
         flags = ["--network #{env_config.network_name}"]
-        # Active Storage signs presigned URLs for the public storage
-        # host; the browser reaches it via Traefik on the host. The app
+        # Active Storage signs presigned URLs for the storage host; the
+        # browser reaches it via Traefik on the host, and the app
         # container must reach the *same* host (presign binds it) for
-        # server-side blob ops — route it to the Docker host where
-        # Traefik :443 lives. Dev only; prod resolves it for real (#44).
-        if env_config.short == "dev"
-          flags << "--add-host=storage.workeverywhere.docker:host-gateway"
-        end
+        # server-side blob ops. Locally there is no real DNS, so point
+        # both the S3 API host and the bucket host at the Docker host
+        # where Traefik :443 terminates. bin/cli only ever runs locally
+        # (real prod uses Kamal), so this applies to dev and the local
+        # production-mode stack alike.
+        flags << "--add-host=storage.workeverywhere.docker:host-gateway"
+        flags << "--add-host=bucket.workeverywhere.docker:host-gateway"
         flags
       end
 

--- a/bin/cli-files/services/services_commands.rb
+++ b/bin/cli-files/services/services_commands.rb
@@ -13,6 +13,7 @@ module AppCLI
       def list
         say("app")
         say("db")
+        say("storage")
       end
 
       desc "status [ENV]", "Check status of services"
@@ -20,6 +21,7 @@ module AppCLI
         manager = manager(env)
         {
           "#{Services::APP_NAME} Db" => manager.db.status,
+          "#{Services::APP_NAME} Storage" => manager.storage.status,
           "#{Services::APP_NAME} App" => manager.app.status
         }.each do |label, service_status|
           say(runner.format_status(label, service_status))

--- a/bin/cli-files/services/services_manager.rb
+++ b/bin/cli-files/services/services_manager.rb
@@ -3,34 +3,44 @@
 require_relative "helpers"
 require_relative "../app-cmd/app_service"
 require_relative "../db-cmd/db_service"
+require_relative "../storage-cmd/storage_service"
 
 module AppCLI
   module Services
     class ServicesManager
-      attr_reader :app, :db
+      attr_reader :app, :db, :storage
 
       def initialize(shell:, env: nil)
         @app = AppService.new(shell: shell, env: env)
         @db = DbService.new(shell: shell, env: env)
+        @storage = StorageService.new(shell: shell)
       end
 
+      # Active Storage points at SeaweedFS S3 in both dev and prod
+      # (config/storage.yml + config/environments/*.rb), so storage is a
+      # first-class service started alongside db/app rather than a manual
+      # `bin/cli storage start` step.
       def setup_all
         db.setup
+        storage.setup
         app.setup
       end
 
       def build_all
         db.build
+        storage.build
         app.build
       end
 
       def start_all
         db.start
+        storage.start
         app.start
       end
 
       def stop_all
         app.stop
+        storage.stop
         db.stop
       end
 
@@ -41,6 +51,7 @@ module AppCLI
 
       def teardown_all
         app.teardown
+        storage.teardown
         db.teardown
       end
     end

--- a/bin/cli-files/storage-cmd/storage_service.rb
+++ b/bin/cli-files/storage-cmd/storage_service.rb
@@ -17,12 +17,32 @@ module AppCLI
       STORAGE_ROUTER = "catalyst-seaweedfs".freeze
       STORAGE_VOLUME = "catalyst-seaweedfs-data".freeze
       STORAGE_BUCKET = "catalyst".freeze
+      # Virtual-host bucket access: bucket.workeverywhere.docker/<key>
+      # resolves to the catalyst bucket via a Traefik addPrefix
+      # middleware. Both routers share the single S3 gateway on :8333.
+      BUCKET_HOST = "bucket.workeverywhere.docker".freeze
+      BUCKET_ROUTER = "catalyst-bucket".freeze
+      BUCKET_MIDDLEWARE = "catalyst-bucket-prefix".freeze
       # App origin allowed to direct-upload (dev). Prod origin is #44.
       APP_ORIGIN_HOST = "catalyst.workeverywhere.docker".freeze
 
       def initialize(shell:)
         @runner = CommandRunner.new(shell: shell)
         @shell = shell
+      end
+
+      def setup
+        runner.ensure_network(Services::NETWORK_NAME)
+        runner.ensure_volume(STORAGE_VOLUME)
+      end
+
+      def build
+        if runner.image_exists?(STORAGE_IMAGE)
+          shell.say("Storage image #{STORAGE_IMAGE} already present, skipping pull.")
+        else
+          shell.say("Pulling #{STORAGE_IMAGE} image")
+          runner.run("docker pull #{STORAGE_IMAGE}")
+        end
       end
 
       def start
@@ -55,6 +75,15 @@ module AppCLI
           runner.run("docker stop #{STORAGE_CONTAINER}")
         else
           shell.say("Storage service not running, skipping stop.")
+        end
+      end
+
+      def teardown
+        stop
+        if runner.volume_exists?(STORAGE_VOLUME)
+          runner.remove_volume(STORAGE_VOLUME)
+        else
+          shell.say("Docker volume '#{STORAGE_VOLUME}' not found, skipping removal.")
         end
       end
 
@@ -176,10 +205,24 @@ module AppCLI
           "--network #{Services::NETWORK_NAME}",
           "--volume #{STORAGE_VOLUME}:/data",
           "--label traefik.enable=true",
+          # S3 API host (path-style) — the endpoint the app signs and
+          # reads/writes through.
           "--label 'traefik.http.routers.#{STORAGE_ROUTER}.rule=" \
           "Host(`#{STORAGE_HOST}`)'",
           "--label traefik.http.routers.#{STORAGE_ROUTER}.entrypoints=websecure",
           "--label traefik.http.routers.#{STORAGE_ROUTER}.tls=true",
+          "--label traefik.http.routers.#{STORAGE_ROUTER}.service=#{STORAGE_ROUTER}",
+          # Bucket host — bucket.workeverywhere.docker/<key> maps to the
+          # catalyst bucket by prefixing the path before it reaches the
+          # (path-style) S3 gateway; shares the one backend service.
+          "--label 'traefik.http.routers.#{BUCKET_ROUTER}.rule=" \
+          "Host(`#{BUCKET_HOST}`)'",
+          "--label traefik.http.routers.#{BUCKET_ROUTER}.entrypoints=websecure",
+          "--label traefik.http.routers.#{BUCKET_ROUTER}.tls=true",
+          "--label traefik.http.routers.#{BUCKET_ROUTER}.service=#{STORAGE_ROUTER}",
+          "--label traefik.http.routers.#{BUCKET_ROUTER}.middlewares=#{BUCKET_MIDDLEWARE}",
+          "--label traefik.http.middlewares.#{BUCKET_MIDDLEWARE}." \
+          "addprefix.prefix=/#{STORAGE_BUCKET}",
           "--label traefik.http.services.#{STORAGE_ROUTER}." \
           "loadbalancer.server.port=8333",
           "--label traefik.docker.network=#{Services::NETWORK_NAME}",


### PR DESCRIPTION
## What

Makes the app runnable in **production mode locally** by wiring SeaweedFS storage into `bin/cli`, and exposes the object store through the existing Traefik on two hosts. Closes #199.

After #44 switched production Active Storage to SeaweedFS, the local CLI only ever wired storage for dev-shaped runs, so a prod-mode app could not reach the object store.

## Changes

- **`storage` is a first-class orchestrated service.** `ServicesManager` now starts/stops/builds/tears down the SeaweedFS container alongside `db` and `app`, and `services list`/`status` report it. Active Storage uses SeaweedFS S3 in both dev and prod, so `bin/cli app start` no longer needs a separate manual `bin/cli storage start`.
- **Bucket host via Traefik.** A second router serves `https://bucket.workeverywhere.docker/<key>`, mapped to the `catalyst` bucket with an `addPrefix=/catalyst` middleware in front of the path-style S3 gateway. `https://storage.workeverywhere.docker/` remains the signed S3 API endpoint.
- **Prod app can reach storage.** Dropped the dev-only gate on the `--add-host` entries so the production-mode app container also resolves `storage.workeverywhere.docker` / `bucket.workeverywhere.docker` to the Docker host where Traefik :443 terminates. (`bin/cli` only ever runs locally; real prod uses Kamal.)
- Added `setup`/`build`/`teardown` to `StorageService` to fit the orchestration lifecycle.

TLS is unchanged: `ssl_verify_peer: Rails.env.production?` stays true (the local CA is trusted in-container).

## Verification

- `bundle exec rubocop` on the changed files: **no offenses**.
- `bin/cli storage start` brings up `seaweedfs` with both Traefik routers. Live HTTPS through Traefik:
  - `GET https://storage.workeverywhere.docker/` → `200`
  - `PUT https://storage.workeverywhere.docker/catalyst/probe.txt` → `200`
  - `GET https://bucket.workeverywhere.docker/probe.txt` → returns the object, `200` (proves the bucket-host → `catalyst` mapping)

## Not in scope

- Real production (Kamal/Doppler) is untouched.
- Full prod-image boot + browser walkthrough was not run in this session (heavy prod build); the storage + routing layer this PR changes is verified above.
