### PR TITLE
fix(ci): bump checkout action to v6 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary

The `deploy.yml` workflow pinned `actions/checkout@v4`, which runs on the **deprecated Node.js 20 runtime**. GitHub Actions surfaces this as a warning on every deploy run and will force these actions to Node.js 24 by default starting June 16, 2026.

This bumps the action to `@v6` (Node.js 24), matching the version already used in `ci.yml`, and clears the warning.

## Changes

- `.github/workflows/deploy.yml`: `actions/checkout@v4` → `@v6`

## Notes

This was the only Node 20 action in the warning. The other actions across the workflows are already on the Node 24 runtime (`ruby/setup-ruby@v1`, `docker/setup-buildx-action@v4`, `webfactory/ssh-agent@v0.10.0`, `dopplerhq/cli-action@v4`, `dependabot/fetch-metadata@v3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)