### PR TITLE
feat(ci): Codex release bug scan on tag push

### DIFF
--- a/.github/codex/release-bug-scan-prompt.md
+++ b/.github/codex/release-bug-scan-prompt.md
@@ -1,0 +1,58 @@
+You are a senior release engineer performing a **pre-release bug scan** on a Ruby
+on Rails 8.1 application (Phlex views, Hotwire, Rodauth auth, Packwerk packs, an
+MCP API, PaperTrail versioning, and a Discard-based soft-delete safety net).
+
+A release tag has just been pushed. Your job is to review **only the changes
+introduced since the previous release tag** and surface the things a human should
+look at before this release is trusted in production. The diff range and tag
+context are provided at the top of this prompt.
+
+## What to do
+
+1. Inspect the diff for the given range with git, e.g.
+   `git diff --stat <range>` then `git diff <range> -- <path>` for the files that
+   matter. Read surrounding code when a hunk is not self-explanatory.
+2. Focus your judgement on:
+   - **Likely regressions** — behaviour that worked before and may now break.
+   - **Fragile areas** — changes to auth (Rodauth), authorization
+     (ActionPolicy), money/state machines, migrations, the soft-delete
+     `default_scope`/`with_discarded` rules, PaperTrail/AuditLog capture, MCP
+     tool surface, or background jobs.
+   - **Suspicious changes** — silent rescue/`rescue nil`, broadened scopes,
+     removed validations or callbacks, N+1 risks, missing `dependent:` handling,
+     changed security/permission defaults, secrets or tokens in code.
+   - **Code that deserves human review** even if not provably wrong.
+3. Prefer a few **high-signal** findings over an exhaustive list. If the diff is
+   low-risk, say so plainly — do not invent findings to fill space.
+4. Do **not** modify any files. This is a read-only analysis.
+
+## Output format
+
+Return **concise GitHub-flavoured Markdown** only (no preamble, no code fences
+around the whole thing), structured exactly like this:
+
+```
+## 🔎 Release Bug Scan
+
+**Overall risk:** Low | Medium | High — one-sentence justification.
+
+### Findings
+
+#### 1. <short title> — `Severity: High|Medium|Low` · `Confidence: High|Medium|Low`
+- **Where:** `path/to/file.rb:line` (and related files)
+- **Why it matters:** what could go wrong in production.
+- **Suggested check:** the concrete thing a human should verify or test.
+
+#### 2. ...
+
+### Looks fine / lower priority
+- Brief bullets for notable-but-acceptable changes, if any.
+```
+
+Rules for the output:
+- Order findings by severity (highest first).
+- Always include `Severity` and `Confidence` on each finding.
+- Reference real file paths and line numbers from the diff.
+- If there are no meaningful findings, keep the "Findings" section empty and set
+  the overall risk to Low with a clear explanation. Keep the whole report under
+  roughly 400 lines.

--- a/.github/workflows/release-bug-scan.yml
+++ b/.github/workflows/release-bug-scan.yml
@@ -40,8 +40,13 @@ jobs:
           if [ -n "${previous}" ]; then
             range="${previous}..${current}"
           else
-            # First release: scan the whole tree.
-            range="${current}"
+            # First release: diff the whole tree against the empty tree so the
+            # scan sees every file as an addition. A bare "${current}" would diff
+            # the tag against the (identical) checked-out working tree — i.e.
+            # nothing. git hash-object derives the empty-tree hash portably
+            # (works for SHA-256 repos too).
+            empty_tree="$(git hash-object -t tree /dev/null)"
+            range="${empty_tree}..${current}"
           fi
           echo "current=${current}"   >> "$GITHUB_OUTPUT"
           echo "previous=${previous}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-bug-scan.yml
+++ b/.github/workflows/release-bug-scan.yml
@@ -1,0 +1,92 @@
+name: Release Bug Scan
+
+run-name: ${{ github.actor }} - Release Bug Scan - ${{ github.ref_name }}
+
+# Runs an automated Codex bug scan whenever a release tag is pushed.
+# Releases are tagged `phase-N` (see "Release Rules" in CLAUDE.md / AGENTS.md);
+# tag pushes do not trigger deploy.yml (that is branch-push only), so this scan
+# runs independently and never interferes with a deploy.
+on:
+  push:
+    tags:
+      - 'phase-*'
+
+# Least privilege: the scan only reads the code and publishes a summary/artifact.
+permissions:
+  contents: read
+
+# One scan per tag; a re-pushed tag supersedes an in-flight run.
+concurrency:
+  group: release-bug-scan-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout tagged code
+        uses: actions/checkout@v6
+        with:
+          # Full history + tags so we can diff this tag against the previous one.
+          fetch-depth: 0
+
+      - name: Resolve diff range
+        id: range
+        run: |
+          current="${GITHUB_REF_NAME}"
+          # Previous release tag reachable from this tag's first parent.
+          previous="$(git describe --tags --abbrev=0 "${current}^" 2>/dev/null || true)"
+          if [ -n "${previous}" ]; then
+            range="${previous}..${current}"
+          else
+            # First release: scan the whole tree.
+            range="${current}"
+          fi
+          echo "current=${current}"   >> "$GITHUB_OUTPUT"
+          echo "previous=${previous}" >> "$GITHUB_OUTPUT"
+          echo "range=${range}"       >> "$GITHUB_OUTPUT"
+          echo "Scanning range: ${range}"
+
+      - name: Build Codex prompt
+        run: |
+          {
+            echo "## Release under review"
+            echo "- Current tag: \`${CURRENT_TAG}\`"
+            echo "- Previous tag: \`${PREVIOUS_TAG:-<none — first release>}\`"
+            echo "- Diff range (git revision range): \`${DIFF_RANGE}\`"
+            echo
+            cat .github/codex/release-bug-scan-prompt.md
+          } > "${RUNNER_TEMP}/codex-prompt.md"
+        env:
+          CURRENT_TAG: ${{ steps.range.outputs.current }}
+          PREVIOUS_TAG: ${{ steps.range.outputs.previous }}
+          DIFF_RANGE: ${{ steps.range.outputs.range }}
+
+      - name: Run Codex bug scan
+        id: scan
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          # Read-only: the scan analyses code, it never edits the working tree.
+          sandbox: read-only
+          prompt-file: ${{ runner.temp }}/codex-prompt.md
+          output-file: release-bug-scan.md
+
+      - name: Publish report to job summary
+        if: always()
+        run: |
+          if [ -s release-bug-scan.md ]; then
+            cat release-bug-scan.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## 🔎 Release Bug Scan" >> "$GITHUB_STEP_SUMMARY"
+            echo "_No report was produced — check the Codex step logs above._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bug-scan-${{ github.ref_name }}
+          path: release-bug-scan.md
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes #203

## What

Adds an automated **Codex release bug scan** that runs when a release tag is pushed, producing a concise release-risk summary for engineers.

## Why

The team already uses Codex for PR review, but there's no automated check at the **release** boundary. Releases are tagged `phase-N`, and tag pushes don't trigger `deploy.yml`, so this is a natural, unused hook point to scan tagged code for last-mile regression risk.

## How

New, additive workflow `.github/workflows/release-bug-scan.yml`:

- **Trigger:** `push` on `phase-*` tags (the repo's release convention).
- **Diff range:** previous release tag → current tag via `git describe --tags --abbrev=0 <tag>^`, with a whole-tree fallback on the first release.
- **Engine:** `openai/codex-action@v1` in `read-only` sandbox — analysis only, never edits the tree.
- **Prompt:** versioned asset `.github/codex/release-bug-scan-prompt.md`, steering toward high-signal findings (regressions; fragile auth/policy/migration/soft-delete/PaperTrail/MCP areas; suspicious silent-rescue/scope/validation changes) with **Severity + Confidence** per finding and an overall risk verdict.
- **Output:** job summary (`$GITHUB_STEP_SUMMARY`) + per-tag artifact.
- **Security:** `permissions: contents: read` only; per-tag `concurrency` guard.

Existing workflows are untouched.

## Required configuration

- Add an **`OPENAI_API_KEY`** repository secret (the action authenticates via the Responses API). The repo has no OpenAI secret today.

## Verification

- YAML validated; trigger confirmed as `push → tags → phase-*`; permissions read-only; 6 steps ordered correctly.
- Prompt-file path consistent between writer step (`\$RUNNER_TEMP`) and action input (`runner.temp`).
- No Ruby/runtime code changed — CI `paths-ignore` does not apply (workflow files are runtime-relevant), but there is nothing for the test suite to exercise here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)